### PR TITLE
oauth2: recognise different identities by GrantType

### DIFF
--- a/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryTokens.java
+++ b/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryTokens.java
@@ -3,6 +3,7 @@ package com.clouway.oauth2.exampleapp.storage;
 import com.clouway.oauth2.DateTime;
 import com.clouway.oauth2.Duration;
 import com.clouway.oauth2.client.Client;
+import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.token.Token;
 import com.clouway.oauth2.token.TokenGenerator;
 import com.clouway.oauth2.token.TokenType;
@@ -37,7 +38,7 @@ class InMemoryTokens implements Tokens {
         //remove the current token
         tokens.remove(tokenValue);
         // new instance
-        Token updatedToken = new Token(token.value, token.type, token.refreshToken, token.identityId, token.clientId, timeToLive.seconds, instant);
+        Token updatedToken = new Token(token.value, token.type, token.grantType, token.refreshToken, token.identityId, token.clientId, timeToLive.seconds, instant);
         //add the new token
         tokens.put(tokenValue, updatedToken);
 
@@ -57,7 +58,7 @@ class InMemoryTokens implements Tokens {
 
         String newTokenValue = tokenGenerator.generate();
 
-        Token updatedToken = new Token(newTokenValue, TokenType.BEARER, token.refreshToken, token.identityId, token.clientId, timeToLive.seconds, instant);
+        Token updatedToken = new Token(newTokenValue, TokenType.BEARER, token.grantType, token.refreshToken, token.identityId, token.clientId, timeToLive.seconds, instant);
 
         //add the new token
         tokens.put(updatedToken.value, updatedToken);
@@ -69,11 +70,11 @@ class InMemoryTokens implements Tokens {
   }
 
   @Override
-  public Token issueToken(Client client, String identityId, DateTime instant) {
+  public Token issueToken(GrantType grantType, Client client, String identityId, DateTime instant) {
     String token = tokenGenerator.generate();
     String refreshTokenValue = tokenGenerator.generate();
 
-    Token bearerToken = new Token(token, TokenType.BEARER, refreshTokenValue, identityId, client.id, timeToLive.seconds, instant);
+    Token bearerToken = new Token(token, TokenType.BEARER, GrantType.JWT, refreshTokenValue, identityId, client.id, timeToLive.seconds, instant);
 
     tokens.put(token, bearerToken);
 

--- a/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryUserRepository.java
+++ b/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryUserRepository.java
@@ -4,6 +4,7 @@ import com.clouway.friendlyserve.Request;
 import com.clouway.oauth2.DateTime;
 import com.clouway.oauth2.Identity;
 import com.clouway.oauth2.exampleapp.UserRepository;
+import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.user.IdentityFinder;
 import com.clouway.oauth2.user.User;
 import com.google.common.base.Optional;
@@ -27,8 +28,12 @@ class InMemoryUserRepository implements IdentityFinder, UserRepository {
   }
 
   @Override
-  public Optional<Identity> findIdentity(String identityId, DateTime instantTime) {
-    return Optional.of(new Identity("testUserID", "testUser", "test User", "User Family", "test@clouway.com", null, Collections.<String, Object>emptyMap()));
+  public Optional<Identity> findIdentity(String identityId, GrantType grantType, DateTime instantTime) {
+    if (grantType == GrantType.AUTHORIZATION_CODE) {
+      return Optional.of(new Identity("testUserID", "testUser", "test User", "User Family", "test@clouway.com", null, Collections.<String, Object>emptyMap()));
+    } else {
+      return Optional.of(new Identity("customerapp@testapp.com", "testapp@testapp.com", "Customer Portal", "", "", "", Collections.<String, Object>emptyMap()));
+    }
   }
 
   @Override

--- a/oauth2-server/src/main/java/com/clouway/oauth2/IssueNewTokenActivity.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/IssueNewTokenActivity.java
@@ -5,6 +5,7 @@ import com.clouway.friendlyserve.Response;
 import com.clouway.oauth2.authorization.Authorization;
 import com.clouway.oauth2.authorization.ClientAuthorizationRepository;
 import com.clouway.oauth2.client.Client;
+import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.token.Token;
 import com.clouway.oauth2.token.Tokens;
 import com.google.common.base.Optional;
@@ -37,7 +38,7 @@ public class IssueNewTokenActivity implements ClientActivity {
 
     Authorization authorization = possibleResponse.get();
 
-    Token newToken = tokens.issueToken(client, authorization.identityId, instant);
+    Token newToken = tokens.issueToken(GrantType.AUTHORIZATION_CODE, client, authorization.identityId, instant);
 
     return new BearerTokenResponse(newToken.value, newToken.expiresInSeconds, newToken.refreshToken);
   }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/UserInfoController.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/UserInfoController.java
@@ -36,7 +36,7 @@ class UserInfoController implements InstantaneousRequest {
 
     Token token = possibleTokenResponse.get();
 
-    Optional<Identity> possibleIdentityResponse = identityFinder.findIdentity(token.identityId, instantTime);
+    Optional<Identity> possibleIdentityResponse = identityFinder.findIdentity(token.identityId, token.grantType, instantTime);
     if (!possibleIdentityResponse.isPresent()) {
       return OAuthError.unknownClient();
     }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/jwt/JwtController.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/jwt/JwtController.java
@@ -11,6 +11,7 @@ import com.clouway.oauth2.client.ServiceAccount;
 import com.clouway.oauth2.client.ServiceAccountRepository;
 import com.clouway.oauth2.jws.Signature;
 import com.clouway.oauth2.jws.SignatureFactory;
+import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.token.Token;
 import com.clouway.oauth2.token.Tokens;
 import com.google.common.base.Optional;
@@ -78,7 +79,7 @@ public class JwtController implements InstantaneousRequest {
       return OAuthError.invalidGrant();
     }
 
-    Token token = tokens.issueToken(new Client(serviceAccount.clientId(), "", "", "", "", ""), serviceAccount.clientId(), instant);
+    Token token = tokens.issueToken(GrantType.JWT, new Client(serviceAccount.clientId(), "", "", "", "", ""), serviceAccount.clientId(), instant);
 
     return new BearerTokenResponse(token.value, token.expiresInSeconds, token.refreshToken);
   }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/token/GrantType.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/token/GrantType.java
@@ -1,0 +1,10 @@
+package com.clouway.oauth2.token;
+
+/**
+ * GrantType is representing the type of the grant that was issued.
+ *
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+public enum GrantType {
+  AUTHORIZATION_CODE, JWT
+}

--- a/oauth2-server/src/main/java/com/clouway/oauth2/token/Token.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/token/Token.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 public final class Token implements Serializable {
   public final String value;
   public final TokenType type;
+  public final GrantType grantType;
   public final String refreshToken;
   public final String identityId;
   public final String clientId;
@@ -18,12 +19,13 @@ public final class Token implements Serializable {
   public final DateTime creationDate;
 
   public Token() {
-    this(null, null, null, null, null, null, null);
+    this(null, null, null, null, null, null, null, null);
   }
 
-  public Token(String value, TokenType type, String refreshToken, String identityId, String clientId, Long expiresInSeconds, DateTime creationDate) {
+  public Token(String value, TokenType type, GrantType grantType, String refreshToken, String identityId, String clientId, Long expiresInSeconds, DateTime creationDate) {
     this.value = value;
     this.type = type;
+    this.grantType = grantType;
     this.refreshToken = refreshToken;
     this.identityId = identityId;
     this.clientId = clientId;

--- a/oauth2-server/src/main/java/com/clouway/oauth2/token/Tokens.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/token/Tokens.java
@@ -31,12 +31,14 @@ public interface Tokens {
   /**
    * Ussues a new token for the provided identity.
    *
+   *
+   * @param grantType
    * @param client the client to which token will be ussued
    * @param identityId the identityId for which token was issued
    * @param when the requested time on which it should be issued
    * @return the newly issued token
    */
-  Token issueToken(Client client, String identityId, DateTime when);
+  Token issueToken(GrantType grantType, Client client, String identityId, DateTime when);
 
   /**
    * Revokes token from repository.

--- a/oauth2-server/src/main/java/com/clouway/oauth2/user/IdentityFinder.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/user/IdentityFinder.java
@@ -3,6 +3,7 @@ package com.clouway.oauth2.user;
 import com.clouway.oauth2.DateTime;
 import com.clouway.oauth2.Identity;
 import com.clouway.friendlyserve.Request;
+import com.clouway.oauth2.token.GrantType;
 import com.google.common.base.Optional;
 
 /**
@@ -20,5 +21,5 @@ public interface IdentityFinder {
    */
   Optional<String> find(Request request, DateTime instantTime);
 
-  Optional<Identity> findIdentity(String identityId, DateTime instantTime);
+  Optional<Identity> findIdentity(String identityId, GrantType grantType, DateTime instantTime);
 }

--- a/oauth2-server/src/test/java/com/clouway/oauth2/IssueNewTokenForClientTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/IssueNewTokenForClientTest.java
@@ -6,6 +6,7 @@ import com.clouway.oauth2.client.Client;
 import com.clouway.friendlyserve.Response;
 import com.clouway.friendlyserve.testing.ParamRequest;
 import com.clouway.friendlyserve.testing.RsPrint;
+import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.token.Tokens;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
@@ -46,7 +47,7 @@ public class IssueNewTokenForClientTest {
       oneOf(clientAuthorizationRepository).findAuthorization(with(any(Client.class)), with(any(String.class)));
       will(returnValue(Optional.of(new Authorization("", "", "::auth_code::", "::redirect_uri::", "::user_id::"))));
 
-      oneOf(tokens).issueToken(client, "::user_id::", anyTime);
+      oneOf(tokens).issueToken(GrantType.AUTHORIZATION_CODE, client, "::user_id::", anyTime);
       will(returnValue(aNewToken().withValue("::token::").build()));
     }});
 

--- a/oauth2-server/src/test/java/com/clouway/oauth2/RefreshTokenForClientTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/RefreshTokenForClientTest.java
@@ -4,6 +4,7 @@ import com.clouway.friendlyserve.Response;
 import com.clouway.friendlyserve.testing.ParamRequest;
 import com.clouway.friendlyserve.testing.RsPrint;
 import com.clouway.oauth2.client.Client;
+import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.token.Token;
 import com.clouway.oauth2.token.TokenType;
 import com.clouway.oauth2.token.Tokens;
@@ -40,7 +41,7 @@ public class RefreshTokenForClientTest {
 
     context.checking(new Expectations() {{
       oneOf(tokens).refreshToken("::refresh_token::", anyTime);
-      will(returnValue(Optional.of(new Token("::token1::", TokenType.BEARER, "::refresh_token::", "","", 600L, new DateTime()))));
+      will(returnValue(Optional.of(new Token("::token1::", TokenType.BEARER, GrantType.AUTHORIZATION_CODE, "::refresh_token::", "","", 600L, new DateTime()))));
     }});
 
     Response response = action.execute(client, new ParamRequest(ImmutableMap.of("refresh_token", "::refresh_token::")), anyTime);

--- a/oauth2-server/src/test/java/com/clouway/oauth2/RetrieveUserInfoWithAccessTokenTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/RetrieveUserInfoWithAccessTokenTest.java
@@ -4,6 +4,7 @@ import com.clouway.friendlyserve.Request;
 import com.clouway.friendlyserve.Response;
 import com.clouway.friendlyserve.testing.ParamRequest;
 import com.clouway.friendlyserve.testing.RsPrint;
+import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.token.Token;
 import com.clouway.oauth2.token.TokenType;
 import com.clouway.oauth2.token.Tokens;
@@ -44,9 +45,9 @@ public class RetrieveUserInfoWithAccessTokenTest {
 
     context.checking(new Expectations() {{
       oneOf(tokens).findTokenAvailableAt("::any token id::", anyInstantTime);
-      will(returnValue(Optional.of(new Token("", TokenType.BEARER, "", "::identity_id::","", 10L, anyInstantTime))));
+      will(returnValue(Optional.of(new Token("", TokenType.BEARER, GrantType.AUTHORIZATION_CODE, "", "::identity_id::","", 10L, anyInstantTime))));
 
-      oneOf(identityFinder).findIdentity("::identity_id::", anyInstantTime);
+      oneOf(identityFinder).findIdentity("::identity_id::", GrantType.AUTHORIZATION_CODE, anyInstantTime);
       will(returnValue(Optional.of(new Identity("985", "::user name::", "::user given name::", "::family name::", "::user email::", "::user picture::", Collections.<String, Object>emptyMap()))));
     }});
 
@@ -70,9 +71,9 @@ public class RetrieveUserInfoWithAccessTokenTest {
 
     context.checking(new Expectations() {{
       oneOf(tokens).findTokenAvailableAt(with(any(String.class)), with(any(DateTime.class)));
-      will(returnValue(Optional.of(new Token("", TokenType.BEARER, "", "::identity_id::", "", 10L, anyInstantTime))));
+      will(returnValue(Optional.of(new Token("", TokenType.BEARER, GrantType.AUTHORIZATION_CODE,"", "::identity_id::", "", 10L, anyInstantTime))));
 
-      oneOf(identityFinder).findIdentity("::identity_id::", anyInstantTime);
+      oneOf(identityFinder).findIdentity("::identity_id::", GrantType.AUTHORIZATION_CODE, anyInstantTime);
       will(returnValue(Optional.of(new Identity("985", "::user name::", "::user given name::", "::family name::", "::user email::", "::user picture::",
               ImmutableMap.<String, Object>of("claim1", "::any string value::", "claim2", 342)))));
     }});
@@ -111,9 +112,9 @@ public class RetrieveUserInfoWithAccessTokenTest {
 
     context.checking(new Expectations() {{
       oneOf(tokens).findTokenAvailableAt("::any token id::", anyInstantTime);
-      will(returnValue(Optional.of(new Token("", TokenType.BEARER, "", "::identity_id::", "", 10L, anyInstantTime))));
+      will(returnValue(Optional.of(new Token("", TokenType.BEARER, GrantType.JWT,"", "::identity_id::", "", 10L, anyInstantTime))));
 
-      oneOf(identityFinder).findIdentity("::identity_id::", anyInstantTime);
+      oneOf(identityFinder).findIdentity("::identity_id::", GrantType.JWT, anyInstantTime);
       will(returnValue(Optional.absent()));
     }});
 

--- a/oauth2-server/src/test/java/com/clouway/oauth2/TokenBuilder.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/TokenBuilder.java
@@ -1,5 +1,6 @@
 package com.clouway.oauth2;
 
+import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.token.Token;
 import com.clouway.oauth2.token.TokenType;
 
@@ -33,7 +34,7 @@ public class TokenBuilder {
   }
 
   public Token build() {
-    return new Token(value, type, "", "", clientId, timeToLiveInSeconds, createdOn);
+    return new Token(value, type, GrantType.AUTHORIZATION_CODE, "", "", clientId, timeToLiveInSeconds, createdOn);
   }
 
   public TokenBuilder forClient(String clientId) {

--- a/oauth2-server/src/test/java/com/clouway/oauth2/jwt/HandleJwtTokenRequestsTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/jwt/HandleJwtTokenRequestsTest.java
@@ -11,6 +11,7 @@ import com.clouway.friendlyserve.Request;
 import com.clouway.friendlyserve.Response;
 import com.clouway.oauth2.jws.Signature;
 import com.clouway.oauth2.jws.SignatureFactory;
+import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.token.Token;
 import com.clouway.oauth2.token.TokenType;
 import com.clouway.oauth2.token.Tokens;
@@ -86,8 +87,8 @@ public class HandleJwtTokenRequestsTest {
       oneOf(anySignatureThatWillVerifies).verify(with(signatureAsBytes), with(matching("::private_key::")));
       will(returnValue(true));
 
-      oneOf(tokens).issueToken(with(any(Client.class)),with(any(String.class)),with(any(DateTime.class)));
-      will(returnValue(new Token("::token_value::", TokenType.BEARER, "::refresh_token::", "::client_id::", "::client_id::", 1000L, new DateTime())));
+      oneOf(tokens).issueToken(with(any(GrantType.class)), with(any(Client.class)),with(any(String.class)),with(any(DateTime.class)));
+      will(returnValue(new Token("::token_value::", TokenType.BEARER, GrantType.AUTHORIZATION_CODE, "::refresh_token::", "::client_id::", "::client_id::", 1000L, new DateTime())));
     }});
 
     Response response = controller.handleAsOf(newJwtRequest(String.format("%s.%s.%s", "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9", body, signature)), anyInstantTime);

--- a/oauth2-server/src/test/java/com/clouway/oauth2/token/TokenEqualityTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/token/TokenEqualityTest.java
@@ -17,8 +17,8 @@ public class TokenEqualityTest {
   @Test
   public void areEqual() {
     DateTime creationDate = new DateTime();
-    Token token1 = new Token("value", TokenType.BEARER, "refreshToken", "identityId", "::client id::", 1L, creationDate);
-    Token token2 = new Token("value", TokenType.BEARER, "refreshToken", "identityId", "::client id::", 1L, creationDate);
+    Token token1 = new Token("value", TokenType.BEARER, GrantType.AUTHORIZATION_CODE, "refreshToken", "identityId", "::client id::", 1L, creationDate);
+    Token token2 = new Token("value", TokenType.BEARER, GrantType.AUTHORIZATION_CODE,"refreshToken", "identityId", "::client id::", 1L, creationDate);
 
     assertThat(token1, is(token2));
   }
@@ -26,16 +26,16 @@ public class TokenEqualityTest {
   @Test
   public void areNotEqual() {
     DateTime creationDate = new DateTime();
-    Token token1 = new Token("value1", TokenType.BEARER, "refreshToken", "identityId", "::client id::", 1L, creationDate);
-    Token token2 = new Token("value2", TokenType.BEARER, "refreshToken", "identityId", "::client id::", 1L, creationDate);
+    Token token1 = new Token("value1", TokenType.BEARER, GrantType.AUTHORIZATION_CODE, "refreshToken", "identityId", "::client id::", 1L, creationDate);
+    Token token2 = new Token("value2", TokenType.BEARER, GrantType.AUTHORIZATION_CODE, "refreshToken", "identityId", "::client id::", 1L, creationDate);
 
     assertThat(token1, is(not(token2)));
   }
 
   @Test
   public void areNotEqualWhenDifferentExpirationTimes() {
-    Token token1 = new Token("value", TokenType.BEARER, "refreshToken", "identityId", "::client id::", 1L, new DateTime(new Date(1408532291030L)));
-    Token token2 = new Token("value", TokenType.BEARER, "refreshToken", "identityId", "::client id::", 1L, new DateTime(new Date(1408532291031L)));
+    Token token1 = new Token("value", TokenType.BEARER, GrantType.AUTHORIZATION_CODE, "refreshToken", "identityId", "::client id::", 1L, new DateTime(new Date(1408532291030L)));
+    Token token2 = new Token("value", TokenType.BEARER, GrantType.AUTHORIZATION_CODE, "refreshToken", "identityId", "::client id::", 1L, new DateTime(new Date(1408532291031L)));
 
     assertThat(token1, is(not(token2)));
   }


### PR DESCRIPTION
Token now contains and grant type which could be used by the applications to separate Service Accounts from Resource Owners.

Fixes #21
