### PR TITLE
oauth2: support multiple redirect urls per client

### DIFF
--- a/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryClientAuthorizationRepository.java
+++ b/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryClientAuthorizationRepository.java
@@ -45,9 +45,8 @@ class InMemoryClientAuthorizationRepository implements ClientAuthorizationReposi
   @Override
   public Optional<Authorization> authorize(Client client, String identityId, String responseType) {
     String code = tokenGenerator.generate();
-    String redirectURI = client.redirectURI;
 
-    Authorization authorization = new Authorization(responseType, client.id, code, redirectURI, identityId);
+    Authorization authorization = new Authorization(responseType, client.id, code, client.redirectURLs, identityId);
     register(authorization);
 
     return Optional.of(authorization);

--- a/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryModule.java
+++ b/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryModule.java
@@ -19,6 +19,8 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 
+import java.util.Collections;
+
 /**
  * @author Ivan Stefanov <ivan.stefanov@clouway.com>
  */
@@ -33,7 +35,7 @@ public class InMemoryModule extends AbstractModule {
     bind(SessionSecurity.class).toInstance(resourceOwnerRepository);
 
     InMemoryClientRepository clientRepository = new InMemoryClientRepository();
-    clientRepository.register(new Client("fe72722a40de846e03865cb3b582aed57841ac71", "857613db7b18232c72a5093ad19dbc6df74a139e", "testname", "http://localhost:8080", "test", "http://localhost:8080/oauth/callback"));
+    clientRepository.register(new Client("fe72722a40de846e03865cb3b582aed57841ac71", "857613db7b18232c72a5093ad19dbc6df74a139e", "testname", "http://localhost:8080", "test", Collections.singleton("http://localhost:8080/oauth/callback")));
     clientRepository.registerServiceAccount("xxx@apps.clouway.com", "-----BEGIN PRIVATE KEY-----\n" +
             "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCH/eazwg0BwuFx\n" +
             "PmXOoauqD54ZPN+3XRF8FxrYo0XvQ8TiJAEJBJo/qjNahn4YYl/6RbP8YLHCe3nd\n" +

--- a/oauth2-example-app/src/test/java/com/clouway/oauth2/exampleapp/ClientRepositoryContractTest.java
+++ b/oauth2-example-app/src/test/java/com/clouway/oauth2/exampleapp/ClientRepositoryContractTest.java
@@ -6,6 +6,8 @@ import com.google.common.base.Optional;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
@@ -25,7 +27,7 @@ public abstract class ClientRepositoryContractTest {
 
   @Test
   public void findById() throws Exception {
-    Client client = new Client("id1", "secret1", "name1", "url1", "description1", "redirectURI1");
+    Client client = new Client("id1", "secret1", "name1", "url1", "description1", Collections.singleton("redirectURI1"));
     repository.register(client);
 
     Optional<Client> actualClient = repository.findById("id1");

--- a/oauth2-server/src/main/java/com/clouway/oauth2/ClientAuthorizationActivity.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/ClientAuthorizationActivity.java
@@ -1,12 +1,12 @@
 package com.clouway.oauth2;
 
+import com.clouway.friendlyserve.Request;
+import com.clouway.friendlyserve.Response;
+import com.clouway.friendlyserve.RsRedirect;
 import com.clouway.oauth2.authorization.Authorization;
 import com.clouway.oauth2.authorization.ClientAuthorizationRepository;
 import com.clouway.oauth2.client.Client;
 import com.clouway.oauth2.client.ClientRepository;
-import com.clouway.friendlyserve.Request;
-import com.clouway.friendlyserve.Response;
-import com.clouway.friendlyserve.RsRedirect;
 import com.google.common.base.Optional;
 
 /**
@@ -25,6 +25,7 @@ class ClientAuthorizationActivity implements IdentityActivity {
   public Response execute(String userId, Request request) {
     String responseType = request.param("response_type");
     String clientId = request.param("client_id");
+    String requestedUrl = request.param("redirect_uri");
 
     Optional<Client> possibleClientResponse = clientRepository.findById(clientId);
 
@@ -34,6 +35,13 @@ class ClientAuthorizationActivity implements IdentityActivity {
 
     Client client = possibleClientResponse.get();
 
+
+    Optional<String> redirectUrl = client.determineRedirectUrl(requestedUrl);
+
+    if (!redirectUrl.isPresent()) {
+      return OAuthError.unauthorizedClient("Client Redirect URL is not matching the configured one.");
+    }
+
     Optional<Authorization> possibleAuthorizationResponse = clientAuthorizationRepository.authorize(client, userId, responseType);
 
     // RFC-6749 - Section: 4.2.2.1
@@ -42,10 +50,10 @@ class ClientAuthorizationActivity implements IdentityActivity {
     // HTTP/1.1 302 Found
     // Location: https://client.example.com/cb#error=access_denied&state=xyz
     if (!possibleAuthorizationResponse.isPresent()) {
-      return new RsRedirect(client.redirectURI + "?error=access_denied");
+      return new RsRedirect(redirectUrl.get() + "?error=access_denied");
     }
 
     Authorization authorization = possibleAuthorizationResponse.get();
-    return new RsRedirect(String.format("%s?code=%s", client.redirectURI, authorization.code));
+    return new RsRedirect(String.format("%s?code=%s", redirectUrl.get(), authorization.code));
   }
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/OAuthError.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/OAuthError.java
@@ -25,6 +25,10 @@ public final class OAuthError extends RsWrap {
     return new OAuthError("unauthorized_client", HttpURLConnection.HTTP_BAD_REQUEST);
   }
 
+  public static OAuthError unauthorizedClient(String description) {
+    return new OAuthError(HttpURLConnection.HTTP_BAD_REQUEST, "unauthorized_client", description);
+  }
+
   public static OAuthError invalidGrant() {
     return new OAuthError("invalid_grant", HttpURLConnection.HTTP_BAD_REQUEST);
   }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/authorization/Authorization.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/authorization/Authorization.java
@@ -1,6 +1,8 @@
 package com.clouway.oauth2.authorization;
 
 import java.util.Date;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * @author Ivan Stefanov <ivan.stefanov@clouway.com>
@@ -9,45 +11,35 @@ public class Authorization {
   public final String responseType;
   public final String clientId;
   public final String code;
-  public final String redirectURI;
+  public final Set<String> redirectUrls;
   public final String identityId;
 
   private Date usageDate = null;
 
-  public Authorization(String responseType, String clientId, String code, String redirectURI, String identityId) {
+  public Authorization(String responseType, String clientId, String code, Set<String> redirectUrls, String identityId) {
     this.responseType = responseType;
     this.clientId = clientId;
     this.code = code;
-    this.redirectURI = redirectURI;
+    this.redirectUrls = redirectUrls;
     this.identityId = identityId;
   }
 
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof Authorization)) return false;
-
+    if (o == null || getClass() != o.getClass()) return false;
     Authorization that = (Authorization) o;
-
-    if (clientId != null ? !clientId.equals(that.clientId) : that.clientId != null) return false;
-    if (code != null ? !code.equals(that.code) : that.code != null) return false;
-    if (redirectURI != null ? !redirectURI.equals(that.redirectURI) : that.redirectURI != null) return false;
-    if (responseType != null ? !responseType.equals(that.responseType) : that.responseType != null) return false;
-    if (usageDate != null ? !usageDate.equals(that.usageDate) : that.usageDate != null) return false;
-    if (identityId != null ? !identityId.equals(that.identityId) : that.identityId != null) return false;
-
-    return true;
+    return Objects.equals(responseType, that.responseType) &&
+            Objects.equals(clientId, that.clientId) &&
+            Objects.equals(code, that.code) &&
+            Objects.equals(redirectUrls, that.redirectUrls) &&
+            Objects.equals(identityId, that.identityId) &&
+            Objects.equals(usageDate, that.usageDate);
   }
 
   @Override
   public int hashCode() {
-    int result = responseType != null ? responseType.hashCode() : 0;
-    result = 31 * result + (clientId != null ? clientId.hashCode() : 0);
-    result = 31 * result + (code != null ? code.hashCode() : 0);
-    result = 31 * result + (redirectURI != null ? redirectURI.hashCode() : 0);
-    result = 31 * result + (identityId != null ? identityId.hashCode() : 0);
-    result = 31 * result + (usageDate != null ? usageDate.hashCode() : 0);
-    return result;
+    return Objects.hash(responseType, clientId, code, redirectUrls, identityId, usageDate);
   }
 
   public void usedOn(Date date) {

--- a/oauth2-server/src/main/java/com/clouway/oauth2/client/Client.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/client/Client.java
@@ -1,6 +1,13 @@
 package com.clouway.oauth2.client;
 
 import com.clouway.oauth2.ClientCredentials;
+import com.google.common.base.Optional;
+import com.google.common.collect.Iterables;
+
+import java.util.Objects;
+import java.util.Set;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
 
 /**
  * @author Ivan Stefanov <ivan.stefanov@clouway.com>
@@ -11,15 +18,27 @@ public class Client {
   public final String name;
   public final String url;
   public final String description;
-  public final String redirectURI;
+  public final Set<String> redirectURLs;
 
-  public Client(String id, String secret, String name, String url, String description, String redirectURI) {
+  public Client(String id, String secret, String name, String url, String description, Set<String> redirectURLs) {
     this.id = id;
     this.secret = secret;
     this.name = name;
     this.url = url;
     this.description = description;
-    this.redirectURI = redirectURI;
+    this.redirectURLs = redirectURLs;
+  }
+
+  public Optional<String> determineRedirectUrl(String requestedUrl) {
+    if (isNullOrEmpty(requestedUrl)) {
+      return Optional.fromNullable(Iterables.getFirst(redirectURLs, "http://client.was.not.configured.properly.com"));
+    }
+
+    if (!redirectURLs.contains(requestedUrl)) {
+      return Optional.absent();
+    }
+
+    return Optional.of(requestedUrl);
   }
 
   public boolean credentialsMatch(ClientCredentials credentials) {
@@ -30,27 +49,18 @@ public class Client {
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-
     Client client = (Client) o;
-
-    if (description != null ? !description.equals(client.description) : client.description != null) return false;
-    if (id != null ? !id.equals(client.id) : client.id != null) return false;
-    if (name != null ? !name.equals(client.name) : client.name != null) return false;
-    if (redirectURI != null ? !redirectURI.equals(client.redirectURI) : client.redirectURI != null) return false;
-    if (secret != null ? !secret.equals(client.secret) : client.secret != null) return false;
-    if (url != null ? !url.equals(client.url) : client.url != null) return false;
-
-    return true;
+    return Objects.equals(id, client.id) &&
+            Objects.equals(secret, client.secret) &&
+            Objects.equals(name, client.name) &&
+            Objects.equals(url, client.url) &&
+            Objects.equals(description, client.description) &&
+            Objects.equals(redirectURLs, client.redirectURLs);
   }
 
   @Override
   public int hashCode() {
-    int result = id != null ? id.hashCode() : 0;
-    result = 31 * result + (secret != null ? secret.hashCode() : 0);
-    result = 31 * result + (name != null ? name.hashCode() : 0);
-    result = 31 * result + (url != null ? url.hashCode() : 0);
-    result = 31 * result + (description != null ? description.hashCode() : 0);
-    result = 31 * result + (redirectURI != null ? redirectURI.hashCode() : 0);
-    return result;
+    return Objects.hash(id, secret, name, url, description, redirectURLs);
   }
+
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/jwt/JwtController.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/jwt/JwtController.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.common.io.BaseEncoding;
 import com.google.gson.Gson;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -79,7 +80,7 @@ public class JwtController implements InstantaneousRequest {
       return OAuthError.invalidGrant();
     }
 
-    Token token = tokens.issueToken(GrantType.JWT, new Client(serviceAccount.clientId(), "", "", "", "", ""), serviceAccount.clientId(), instant);
+    Token token = tokens.issueToken(GrantType.JWT, new Client(serviceAccount.clientId(), "", "", "", "", Collections.<String>emptySet()), serviceAccount.clientId(), instant);
 
     return new BearerTokenResponse(token.value, token.expiresInSeconds, token.refreshToken);
   }

--- a/oauth2-server/src/test/java/com/clouway/oauth2/AuthorizationEqualityTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/AuthorizationEqualityTest.java
@@ -3,6 +3,8 @@ package com.clouway.oauth2;
 import com.clouway.oauth2.authorization.Authorization;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
@@ -13,16 +15,16 @@ import static org.junit.Assert.assertThat;
 public class AuthorizationEqualityTest {
   @Test
   public void areEqual() {
-    Authorization authorization1 = new Authorization("code", "id", "123456", "redirectURI", "identityId");
-    Authorization authorization2 = new Authorization("code", "id", "123456", "redirectURI", "identityId");
+    Authorization authorization1 = new Authorization("code", "id", "123456", Collections.singleton("redirectURI"), "identityId");
+    Authorization authorization2 = new Authorization("code", "id", "123456", Collections.singleton("redirectURI"), "identityId");
 
     assertThat(authorization1, is(authorization2));
   }
 
   @Test
   public void areNotEqual() {
-    Authorization authorization1 = new Authorization("code1", "id1", "123456", "redirectURI1", "identityId");
-    Authorization authorization2 = new Authorization("code2", "id2", "654321", "redirectURI2", "identityId");
+    Authorization authorization1 = new Authorization("code1", "id1", "123456", Collections.singleton("redirectURI1"), "identityId");
+    Authorization authorization2 = new Authorization("code2", "id2", "654321", Collections.singleton("redirectURI2"), "identityId");
 
     assertThat(authorization1, is(not(authorization2)));
   }

--- a/oauth2-server/src/test/java/com/clouway/oauth2/AuthorizeClientsTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/AuthorizeClientsTest.java
@@ -1,12 +1,12 @@
 package com.clouway.oauth2;
 
-import com.clouway.oauth2.client.Client;
-import com.clouway.oauth2.client.ClientRepository;
 import com.clouway.friendlyserve.Request;
 import com.clouway.friendlyserve.Response;
 import com.clouway.friendlyserve.RsText;
 import com.clouway.friendlyserve.testing.ParamRequest;
 import com.clouway.friendlyserve.testing.RsPrint;
+import com.clouway.oauth2.client.Client;
+import com.clouway.oauth2.client.ClientRepository;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import org.jmock.Expectations;
@@ -18,6 +18,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static com.clouway.oauth2.client.ClientBuilder.aNewClient;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 
@@ -107,14 +108,7 @@ public class AuthorizeClientsTest {
   }
 
   private Client newClient(String clientId, String secret) {
-    return new Client(
-            clientId,
-            secret,
-            "::test_client::",
-            "::url::",
-            "::description::",
-            "::redirect::"
-    );
+    return aNewClient().withId(clientId).withSecret(secret).build();
   }
 
 }

--- a/oauth2-server/src/test/java/com/clouway/oauth2/ClientEqualityTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/ClientEqualityTest.java
@@ -3,6 +3,8 @@ package com.clouway.oauth2;
 import com.clouway.oauth2.client.Client;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
@@ -13,16 +15,16 @@ import static org.junit.Assert.assertThat;
 public class ClientEqualityTest {
   @Test
   public void areEqual() {
-    Client client1 = new Client("id", "secret", "name", "url", "description", "redirectURI");
-    Client client2 = new Client("id", "secret", "name", "url", "description", "redirectURI");
+    Client client1 = new Client("id", "secret", "name", "url", "description", Collections.singleton("redirectURI"));
+    Client client2 = new Client("id", "secret", "name", "url", "description", Collections.singleton("redirectURI"));
 
     assertThat(client1, is(client2));
   }
 
   @Test
   public void areNotEqual() {
-    Client client1 = new Client("id1", "secret1", "name1", "url1", "description1", "redirectURI1");
-    Client client2 = new Client("id2", "secret2", "name2", "url2", "description2", "redirectURI2");
+    Client client1 = new Client("id1", "secret1", "name1", "url1", "description1", Collections.singleton("redirectURI1"));
+    Client client2 = new Client("id2", "secret2", "name2", "url2", "description2", Collections.singleton("redirectURI2"));
 
     assertThat(client1, is(not(client2)));
   }

--- a/oauth2-server/src/test/java/com/clouway/oauth2/IssueNewTokenForClientTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/IssueNewTokenForClientTest.java
@@ -16,6 +16,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import static com.clouway.oauth2.TokenBuilder.aNewToken;
 import static com.clouway.oauth2.client.ClientBuilder.aNewClient;
@@ -45,7 +46,7 @@ public class IssueNewTokenForClientTest {
 
     context.checking(new Expectations() {{
       oneOf(clientAuthorizationRepository).findAuthorization(with(any(Client.class)), with(any(String.class)));
-      will(returnValue(Optional.of(new Authorization("", "", "::auth_code::", "::redirect_uri::", "::user_id::"))));
+      will(returnValue(Optional.of(new Authorization("", "", "::auth_code::", Collections.singleton("::redirect_uri::"), "::user_id::"))));
 
       oneOf(tokens).issueToken(GrantType.AUTHORIZATION_CODE, client, "::user_id::", anyTime);
       will(returnValue(aNewToken().withValue("::token::").build()));

--- a/oauth2-server/src/test/java/com/clouway/oauth2/client/ClientBuilder.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/client/ClientBuilder.java
@@ -1,5 +1,7 @@
 package com.clouway.oauth2.client;
 
+import java.util.Collections;
+
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
@@ -29,6 +31,6 @@ public class ClientBuilder {
   }
 
   public Client build() {
-    return new Client(clientId, clientSecret, "test name", "::url::", "::desc::", redirectUrl);
+    return new Client(clientId, clientSecret, "test name", "::url::", "::desc::", Collections.singleton(redirectUrl));
   }
 }


### PR DESCRIPTION
Added support for multiple redirect urls per client. When client sends authorization request to the oauth2 provider it may request and redirect_uri which to be preferred for the callback redirect. If it's not specified then the first one of the list is used.

In cases when the requested URL is fake the oauth2 provider will return bad request with proper information message to indicate that redirectUrl was broken.

Fixes #23
