### PR TITLE
oauth2: split IdentityFinder into 2 interfaces

### DIFF
--- a/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/OauthAuthorizationServerModule.java
+++ b/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/OauthAuthorizationServerModule.java
@@ -9,6 +9,7 @@ import com.clouway.oauth2.client.ServiceAccountFinder;
 import com.clouway.oauth2.exampleapp.security.SecurityModule;
 import com.clouway.oauth2.token.Tokens;
 import com.clouway.oauth2.user.IdentityFinder;
+import com.clouway.oauth2.user.ResourceOwnerIdentityFinder;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
@@ -32,14 +33,16 @@ public class OauthAuthorizationServerModule extends AbstractModule {
     private final ClientRepository clientRepository;
     private final Tokens tokens;
     private final IdentityFinder identityFinder;
+    private final ResourceOwnerIdentityFinder resourceOwnerIdentityFinder;
     private final ServiceAccountFinder serviceAccountFinder;
 
     @Inject
-    public OAuth2ServletBinding(ClientAuthorizationRepository clientAuthorizationRepository, ClientRepository clientRepository, Tokens tokens, IdentityFinder identityFinder, ServiceAccountFinder serviceAccountFinder) {
+    public OAuth2ServletBinding(ClientAuthorizationRepository clientAuthorizationRepository, ClientRepository clientRepository, Tokens tokens, IdentityFinder identityFinder, ResourceOwnerIdentityFinder resourceOwnerIdentityFinder, ServiceAccountFinder serviceAccountFinder) {
       this.clientAuthorizationRepository = clientAuthorizationRepository;
       this.clientRepository = clientRepository;
       this.tokens = tokens;
       this.identityFinder = identityFinder;
+      this.resourceOwnerIdentityFinder = resourceOwnerIdentityFinder;
       this.serviceAccountFinder = serviceAccountFinder;
     }
 
@@ -51,6 +54,7 @@ public class OauthAuthorizationServerModule extends AbstractModule {
               .clientRepository(clientRepository)
               .tokens(tokens)
               .identityFinder(identityFinder)
+              .resourceOwnerIdentityFinder(resourceOwnerIdentityFinder)
               .serviceAccountRepository(serviceAccountFinder)
               .build();
     }

--- a/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryModule.java
+++ b/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryModule.java
@@ -15,6 +15,7 @@ import com.clouway.oauth2.exampleapp.UserRepository;
 import com.clouway.oauth2.token.Tokens;
 import com.clouway.oauth2.token.UrlSafeTokenGenerator;
 import com.clouway.oauth2.user.IdentityFinder;
+import com.clouway.oauth2.user.ResourceOwnerIdentityFinder;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
@@ -74,6 +75,8 @@ public class InMemoryModule extends AbstractModule {
     InMemoryUserRepository userRepository = new InMemoryUserRepository();
 
     bind(IdentityFinder.class).toInstance(userRepository);
+    bind(ResourceOwnerIdentityFinder.class).toInstance(userRepository);
+
     bind(UserRepository.class).toInstance(userRepository);
   }
 

--- a/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryUserRepository.java
+++ b/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryUserRepository.java
@@ -6,6 +6,7 @@ import com.clouway.oauth2.Identity;
 import com.clouway.oauth2.exampleapp.UserRepository;
 import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.user.IdentityFinder;
+import com.clouway.oauth2.user.ResourceOwnerIdentityFinder;
 import com.clouway.oauth2.user.User;
 import com.google.common.base.Optional;
 
@@ -14,7 +15,7 @@ import java.util.Collections;
 /**
  * @author Mihail Lesikov (mlesikov@gmail.com)
  */
-class InMemoryUserRepository implements IdentityFinder, UserRepository {
+class InMemoryUserRepository implements IdentityFinder, ResourceOwnerIdentityFinder, UserRepository {
 
   @Override
   public Optional<String> find(Request request, DateTime instantTime) {

--- a/oauth2-server/src/main/java/com/clouway/oauth2/ClientAuthorizationActivity.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/ClientAuthorizationActivity.java
@@ -22,7 +22,7 @@ class ClientAuthorizationActivity implements IdentityActivity {
   }
 
   @Override
-  public Response execute(String userId, Request request) {
+  public Response execute(String identityId, Request request) {
     String responseType = request.param("response_type");
     String clientId = request.param("client_id");
     String requestedUrl = request.param("redirect_uri");
@@ -42,7 +42,7 @@ class ClientAuthorizationActivity implements IdentityActivity {
       return OAuthError.unauthorizedClient("Client Redirect URL is not matching the configured one.");
     }
 
-    Optional<Authorization> possibleAuthorizationResponse = clientAuthorizationRepository.authorize(client, userId, responseType);
+    Optional<Authorization> possibleAuthorizationResponse = clientAuthorizationRepository.authorize(client, identityId, responseType);
 
     // RFC-6749 - Section: 4.2.2.1
     // The authorization server redirects the user-agent by

--- a/oauth2-server/src/main/java/com/clouway/oauth2/IdentityController.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/IdentityController.java
@@ -3,12 +3,11 @@ package com.clouway.oauth2;
 import com.clouway.friendlyserve.Request;
 import com.clouway.friendlyserve.Response;
 import com.clouway.friendlyserve.RsRedirect;
-import com.clouway.oauth2.user.IdentityFinder;
+import com.clouway.oauth2.user.ResourceOwnerIdentityFinder;
 import com.google.common.base.Optional;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.util.Date;
 
 /**
  * IdentityController is responsible for determining the Identity of the caller. Sent request to this controller
@@ -19,11 +18,11 @@ import java.util.Date;
  */
 final class IdentityController implements InstantaneousRequest {
 
-  private final IdentityFinder identityFinder;
+  private final ResourceOwnerIdentityFinder identityFinder;
   private final IdentityActivity identityActivity;
   private final String loginPageUrl;
 
-  IdentityController(IdentityFinder identityFinder, IdentityActivity identityActivity, String loginPageUrl) {
+  IdentityController(ResourceOwnerIdentityFinder identityFinder, IdentityActivity identityActivity, String loginPageUrl) {
     this.identityFinder = identityFinder;
     this.identityActivity = identityActivity;
     this.loginPageUrl = loginPageUrl;

--- a/oauth2-server/src/main/java/com/clouway/oauth2/OAuth2Config.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/OAuth2Config.java
@@ -5,6 +5,7 @@ import com.clouway.oauth2.client.ClientRepository;
 import com.clouway.oauth2.client.ServiceAccountFinder;
 import com.clouway.oauth2.token.Tokens;
 import com.clouway.oauth2.user.IdentityFinder;
+import com.clouway.oauth2.user.ResourceOwnerIdentityFinder;
 
 /**
  * OAuth2Config is a configuration class which is used to pass configuration from apps to the oauth2-server flow.
@@ -14,6 +15,8 @@ import com.clouway.oauth2.user.IdentityFinder;
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
 public final class OAuth2Config {
+
+
 
   public static OAuth2Config.Builder newConfig() {
     return new OAuth2Config.Builder();
@@ -27,6 +30,7 @@ public final class OAuth2Config {
     private ClientAuthorizationRepository clientAuthorizationRepository;
     private ClientRepository clientRepository;
     private String loginPageUrl;
+    private ResourceOwnerIdentityFinder resourceOwnerIdentityFinder;
 
     public Builder tokens(Tokens tokens) {
       this.tokens = tokens;
@@ -34,6 +38,11 @@ public final class OAuth2Config {
     }
     public Builder identityFinder(IdentityFinder identityFinder) {
       this.identityFinder = identityFinder;
+      return this;
+    }
+
+    public Builder resourceOwnerIdentityFinder(ResourceOwnerIdentityFinder resourceOwnerIdentityFinder) {
+      this.resourceOwnerIdentityFinder = resourceOwnerIdentityFinder;
       return this;
     }
 
@@ -64,7 +73,7 @@ public final class OAuth2Config {
   }
 
   private final IdentityFinder identityFinder;
-
+  private final ResourceOwnerIdentityFinder resourceOwnerIdentityFinder;
   private final ClientRepository clientRepository;
 
   private final Tokens tokens;
@@ -74,6 +83,7 @@ public final class OAuth2Config {
   private OAuth2Config(Builder builder) {
     this.tokens = builder.tokens;
     this.identityFinder = builder.identityFinder;
+    this.resourceOwnerIdentityFinder = builder.resourceOwnerIdentityFinder;
     this.clientRepository = builder.clientRepository;
     this.clientAuthorizationRepository = builder.clientAuthorizationRepository;
     this.serviceAccountFinder = builder.serviceAccountFinder;
@@ -98,6 +108,10 @@ public final class OAuth2Config {
 
   public ClientRepository clientRepository() {
     return this.clientRepository;
+  }
+
+  public ResourceOwnerIdentityFinder resourceOwnerIdentityFinder() {
+    return this.resourceOwnerIdentityFinder;
   }
 
   public String loginPageUrl() {

--- a/oauth2-server/src/main/java/com/clouway/oauth2/OAuth2Servlet.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/OAuth2Servlet.java
@@ -49,7 +49,7 @@ public abstract class OAuth2Servlet extends HttpServlet {
             new FkRegex(".*/auth",
                     new InstantaneousRequestController(
                             new IdentityController(
-                                    config.identityFinder(),
+                                    config.resourceOwnerIdentityFinder(),
                                     new ClientAuthorizationActivity(config.clientRepository(), config.clientAuthorizationRepository()), config.loginPageUrl())
                     )
             ),

--- a/oauth2-server/src/main/java/com/clouway/oauth2/user/IdentityFinder.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/user/IdentityFinder.java
@@ -2,7 +2,6 @@ package com.clouway.oauth2.user;
 
 import com.clouway.oauth2.DateTime;
 import com.clouway.oauth2.Identity;
-import com.clouway.friendlyserve.Request;
 import com.clouway.oauth2.token.GrantType;
 import com.google.common.base.Optional;
 
@@ -12,14 +11,14 @@ import com.google.common.base.Optional;
  * @author Mihail Lesikov (mlesikov@gmail.com)
  */
 public interface IdentityFinder {
-  /**
-   * Finds Identity of the caller.
-   *
-   * @param request the request from which identity will be retrieved
-   * @param instantTime the time on which request was executed
-   * @return an optional value with the identity id if it's associated with the provided request or absent value if not
-   */
-  Optional<String> find(Request request, DateTime instantTime);
 
+  /**
+   * Finds identity of the resource provider by providing it's id and the GrantType that was requested.
+   *
+   * @param identityId  the identityId of the Resource Owner.
+   * @param grantType   the grant type that was acknowledged
+   * @param instantTime the time on which it was requested
+   * @return the associated identity by that id or absent value if it's not available.
+   */
   Optional<Identity> findIdentity(String identityId, GrantType grantType, DateTime instantTime);
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/user/ResourceOwnerIdentityFinder.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/user/ResourceOwnerIdentityFinder.java
@@ -1,0 +1,30 @@
+package com.clouway.oauth2.user;
+
+import com.clouway.friendlyserve.Request;
+import com.clouway.oauth2.DateTime;
+import com.google.common.base.Optional;
+
+/**
+ * ResourceOwnerIdentityFinder is a finder which is used during the authorization of the request.
+ * <p/>
+ * <p>
+ * In most cases implementations of this class should ask the session store for retrieving of the identity which is
+ * assicated with the request.
+ * <p/>
+ *
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+public interface ResourceOwnerIdentityFinder {
+
+  /**
+   * Finds Identity of the caller.
+   * <p/>
+   * In most cases the request will contain a Cookie value which will be used
+   * as lookup key for the session of the Owner which contains and the requested identity.
+   *
+   * @param request     the request from which identity will be retrieved
+   * @param instantTime the time on which request was executed
+   * @return an optional value with the identity id if it's associated with the provided request or absent value if not
+   */
+  Optional<String> find(Request request, DateTime instantTime);
+}

--- a/oauth2-server/src/test/java/com/clouway/oauth2/IdentityControllerTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/IdentityControllerTest.java
@@ -6,7 +6,7 @@ import com.clouway.friendlyserve.RsText;
 import com.clouway.friendlyserve.Status;
 import com.clouway.friendlyserve.testing.ParamRequest;
 import com.clouway.friendlyserve.testing.RsPrint;
-import com.clouway.oauth2.user.IdentityFinder;
+import com.clouway.oauth2.user.ResourceOwnerIdentityFinder;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import org.jmock.Expectations;
@@ -31,7 +31,7 @@ public class IdentityControllerTest {
   public JUnitRuleMockery context = new JUnitRuleMockery();
 
   @Mock
-  IdentityFinder identityFinder;
+  ResourceOwnerIdentityFinder identityFinder;
 
   @Mock
   IdentityActivity identityActivity;


### PR DESCRIPTION
Currently the IdentityFinder was responsible for retrieving of IdentityId from the Request and for retrieving of Identity information from the persistence layer (memory, db and etc). As this tasks are not related a new interface ResourceOwnerIdentityFinder was introduced to separate them.

The new responsibilities now are:
- ResourceOwnerIdentityFinder retrieve identity id from request
- IdentityFinder -> retrieve identity information for the RO
