### PR TITLE
oauth2: remove not used properties from Client object

### DIFF
--- a/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryModule.java
+++ b/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryModule.java
@@ -36,7 +36,7 @@ public class InMemoryModule extends AbstractModule {
     bind(SessionSecurity.class).toInstance(resourceOwnerRepository);
 
     InMemoryClientRepository clientRepository = new InMemoryClientRepository();
-    clientRepository.register(new Client("fe72722a40de846e03865cb3b582aed57841ac71", "857613db7b18232c72a5093ad19dbc6df74a139e", "testname", "http://localhost:8080", "test", Collections.singleton("http://localhost:8080/oauth/callback")));
+    clientRepository.register(new Client("fe72722a40de846e03865cb3b582aed57841ac71", "857613db7b18232c72a5093ad19dbc6df74a139e", "test", Collections.singleton("http://localhost:8080/oauth/callback")));
     clientRepository.registerServiceAccount("xxx@apps.clouway.com", "-----BEGIN PRIVATE KEY-----\n" +
             "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCH/eazwg0BwuFx\n" +
             "PmXOoauqD54ZPN+3XRF8FxrYo0XvQ8TiJAEJBJo/qjNahn4YYl/6RbP8YLHCe3nd\n" +

--- a/oauth2-example-app/src/test/java/com/clouway/oauth2/exampleapp/ClientRepositoryContractTest.java
+++ b/oauth2-example-app/src/test/java/com/clouway/oauth2/exampleapp/ClientRepositoryContractTest.java
@@ -27,7 +27,7 @@ public abstract class ClientRepositoryContractTest {
 
   @Test
   public void findById() throws Exception {
-    Client client = new Client("id1", "secret1", "name1", "url1", "description1", Collections.singleton("redirectURI1"));
+    Client client = new Client("id1", "secret1", "description1", Collections.singleton("redirectURI1"));
     repository.register(client);
 
     Optional<Client> actualClient = repository.findById("id1");

--- a/oauth2-server/src/main/java/com/clouway/oauth2/client/Client.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/client/Client.java
@@ -15,16 +15,12 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 public class Client {
   public final String id;
   public final String secret;
-  public final String name;
-  public final String url;
   public final String description;
   public final Set<String> redirectURLs;
 
-  public Client(String id, String secret, String name, String url, String description, Set<String> redirectURLs) {
+  public Client(String id, String secret, String description, Set<String> redirectURLs) {
     this.id = id;
     this.secret = secret;
-    this.name = name;
-    this.url = url;
     this.description = description;
     this.redirectURLs = redirectURLs;
   }
@@ -52,15 +48,13 @@ public class Client {
     Client client = (Client) o;
     return Objects.equals(id, client.id) &&
             Objects.equals(secret, client.secret) &&
-            Objects.equals(name, client.name) &&
-            Objects.equals(url, client.url) &&
             Objects.equals(description, client.description) &&
             Objects.equals(redirectURLs, client.redirectURLs);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, secret, name, url, description, redirectURLs);
+    return Objects.hash(id, secret, description, redirectURLs);
   }
 
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/jwt/JwtController.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/jwt/JwtController.java
@@ -80,7 +80,7 @@ public class JwtController implements InstantaneousRequest {
       return OAuthError.invalidGrant();
     }
 
-    Token token = tokens.issueToken(GrantType.JWT, new Client(serviceAccount.clientId(), "", "", "", "", Collections.<String>emptySet()), serviceAccount.clientId(), instant);
+    Token token = tokens.issueToken(GrantType.JWT, new Client(serviceAccount.clientId(), "", "", Collections.<String>emptySet()), serviceAccount.clientId(), instant);
 
     return new BearerTokenResponse(token.value, token.expiresInSeconds, token.refreshToken);
   }

--- a/oauth2-server/src/test/java/com/clouway/oauth2/ClientEqualityTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/ClientEqualityTest.java
@@ -15,16 +15,16 @@ import static org.junit.Assert.assertThat;
 public class ClientEqualityTest {
   @Test
   public void areEqual() {
-    Client client1 = new Client("id", "secret", "name", "url", "description", Collections.singleton("redirectURI"));
-    Client client2 = new Client("id", "secret", "name", "url", "description", Collections.singleton("redirectURI"));
+    Client client1 = new Client("id", "secret", "description", Collections.singleton("redirectURI"));
+    Client client2 = new Client("id", "secret", "description", Collections.singleton("redirectURI"));
 
     assertThat(client1, is(client2));
   }
 
   @Test
   public void areNotEqual() {
-    Client client1 = new Client("id1", "secret1", "name1", "url1", "description1", Collections.singleton("redirectURI1"));
-    Client client2 = new Client("id2", "secret2", "name2", "url2", "description2", Collections.singleton("redirectURI2"));
+    Client client1 = new Client("id1", "secret1", "description1", Collections.singleton("redirectURI1"));
+    Client client2 = new Client("id2", "secret2", "description2", Collections.singleton("redirectURI2"));
 
     assertThat(client1, is(not(client2)));
   }

--- a/oauth2-server/src/test/java/com/clouway/oauth2/client/ClientBuilder.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/client/ClientBuilder.java
@@ -31,6 +31,6 @@ public class ClientBuilder {
   }
 
   public Client build() {
-    return new Client(clientId, clientSecret, "test name", "::url::", "::desc::", Collections.singleton(redirectUrl));
+    return new Client(clientId, clientSecret, "::desc::", Collections.singleton(redirectUrl));
   }
 }


### PR DESCRIPTION
Unused properties in the OAuth2 Client object are removed such as:
- name - duplicated with description
- url - not used by the application
