### PR TITLE
oauth2-server: remove primitive obsession of access token

### DIFF
--- a/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryModule.java
+++ b/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryModule.java
@@ -1,7 +1,5 @@
 package com.clouway.oauth2.exampleapp.storage;
 
-import com.clouway.oauth2.Duration;
-
 import com.clouway.oauth2.exampleapp.ResourceOwnerStore;
 import com.clouway.oauth2.authorization.ClientAuthorizationRepository;
 import com.clouway.oauth2.client.Client;
@@ -83,7 +81,7 @@ public class InMemoryModule extends AbstractModule {
   @Provides
   @Singleton
   public Tokens getTokenRepository() {
-    return new InMemoryTokens(new UrlSafeTokenGenerator(), new Duration(900000000L));
+    return new InMemoryTokens(new UrlSafeTokenGenerator());
   }
 
   @Provides

--- a/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryTokens.java
+++ b/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryTokens.java
@@ -3,8 +3,8 @@ package com.clouway.oauth2.exampleapp.storage;
 import com.clouway.oauth2.DateTime;
 import com.clouway.oauth2.Duration;
 import com.clouway.oauth2.client.Client;
-import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.token.BearerToken;
+import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.token.TokenGenerator;
 import com.clouway.oauth2.token.TokenResponse;
 import com.clouway.oauth2.token.Tokens;
@@ -23,12 +23,10 @@ class InMemoryTokens implements Tokens {
   private final Map<String, BearerToken> tokens = Maps.newHashMap();
   private final Map<String, String> refreshTokenToAccessToken = Maps.newHashMap();
   private final TokenGenerator tokenGenerator;
-  private Duration timeToLive;
 
   @Inject
-  public InMemoryTokens(TokenGenerator tokenGenerator, Duration timeToLive) {
+  public InMemoryTokens(TokenGenerator tokenGenerator) {
     this.tokenGenerator = tokenGenerator;
-    this.timeToLive = timeToLive;
   }
 
   @Override
@@ -65,11 +63,11 @@ class InMemoryTokens implements Tokens {
       tokens.put(newTokenValue, updatedToken);
       refreshTokenToAccessToken.put(refreshToken, newTokenValue);
 
-      return new TokenResponse(true, updatedToken.value, refreshToken, updatedToken.ttlSeconds(instant));
+      return new TokenResponse(true, updatedToken, refreshToken);
 
     }
 
-    return new TokenResponse(false, "", "", 0L);
+    return new TokenResponse(false, null, "");
   }
 
   @Override
@@ -77,10 +75,10 @@ class InMemoryTokens implements Tokens {
     String token = tokenGenerator.generate();
     String refreshTokenValue = tokenGenerator.generate();
 
-    BearerToken bearerToken = new BearerToken(token, GrantType.JWT, identityId, client.id, scopes, when);
+    BearerToken bearerToken = new BearerToken(token, GrantType.JWT, identityId, client.id, scopes, when.plusSeconds(10000));
     tokens.put(token, bearerToken);
 
-    return new TokenResponse(true, token, refreshTokenValue, bearerToken.ttlSeconds(when));
+    return new TokenResponse(true, bearerToken, refreshTokenValue);
   }
 
   @Override

--- a/oauth2-server/src/main/java/com/clouway/oauth2/DateTime.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/DateTime.java
@@ -1,11 +1,12 @@
 package com.clouway.oauth2;
 
+import java.io.Serializable;
 import java.util.Date;
 
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
-public final class DateTime {
+public final class DateTime implements Serializable {
   private final Date time;
 
   public DateTime(Date time) {

--- a/oauth2-server/src/main/java/com/clouway/oauth2/IssueNewTokenActivity.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/IssueNewTokenActivity.java
@@ -5,6 +5,7 @@ import com.clouway.friendlyserve.Response;
 import com.clouway.oauth2.authorization.Authorization;
 import com.clouway.oauth2.authorization.ClientAuthorizationRepository;
 import com.clouway.oauth2.client.Client;
+import com.clouway.oauth2.token.BearerToken;
 import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.token.TokenResponse;
 import com.clouway.oauth2.token.Tokens;
@@ -42,6 +43,8 @@ class IssueNewTokenActivity implements ClientActivity {
       return OAuthError.invalidRequest("Token cannot be issued.");
     }
 
-    return new BearerTokenResponse(response.accessToken, response.ttlInSeconds, response.refreshToken);
+    BearerToken accessToken = response.accessToken;
+
+    return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), response.refreshToken);
   }
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/RefreshTokenActivity.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/RefreshTokenActivity.java
@@ -3,6 +3,7 @@ package com.clouway.oauth2;
 import com.clouway.oauth2.client.Client;
 import com.clouway.friendlyserve.Request;
 import com.clouway.friendlyserve.Response;
+import com.clouway.oauth2.token.BearerToken;
 import com.clouway.oauth2.token.TokenResponse;
 import com.clouway.oauth2.token.Tokens;
 
@@ -26,6 +27,8 @@ class RefreshTokenActivity implements ClientActivity {
       return OAuthError.invalidGrant();
     }
 
-    return new BearerTokenResponse(response.accessToken, response.ttlInSeconds, response.refreshToken);
+    BearerToken accessToken = response.accessToken;
+
+    return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), response.refreshToken);
   }
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/jwt/JwtController.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/jwt/JwtController.java
@@ -11,6 +11,7 @@ import com.clouway.oauth2.client.ClientKeyStore;
 import com.clouway.oauth2.jws.Pem;
 import com.clouway.oauth2.jws.Signature;
 import com.clouway.oauth2.jws.SignatureFactory;
+import com.clouway.oauth2.token.BearerToken;
 import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.token.TokenResponse;
 import com.clouway.oauth2.token.Tokens;
@@ -86,8 +87,14 @@ public class JwtController implements InstantaneousRequest {
     Set<String> scopes = Sets.newTreeSet(Splitter.on(" ").omitEmptyStrings().split(scope));
     Client client = new Client(claimSet.iss, "", "", Collections.<String>emptySet());
     TokenResponse response = tokens.issueToken(GrantType.JWT, client, claimSet.iss, scopes, instant);
+    
+    if (!response.isSuccessful()) {
+      return OAuthError.invalidRequest("tokens issuing is temporary unavailable");
+    }
+    
+    BearerToken accessToken = response.accessToken;
 
-    return new BearerTokenResponse(response.accessToken, response.ttlInSeconds, response.refreshToken);
+    return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), response.refreshToken);
   }
 
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/token/TokenResponse.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/token/TokenResponse.java
@@ -11,18 +11,17 @@ package com.clouway.oauth2.token;
 public final class TokenResponse {
   private final boolean successful;
 
-  public final String accessToken;
+  public final BearerToken accessToken;
   public final String refreshToken;
-  public final Long ttlInSeconds;
 
-  public TokenResponse(boolean successful, String accessToken, String refreshToken, Long ttlInSeconds) {
+  public TokenResponse(boolean successful, BearerToken accessToken, String refreshToken) {
     this.successful = successful;
-    this.accessToken = accessToken;
     this.refreshToken = refreshToken;
-    this.ttlInSeconds = ttlInSeconds;
+    this.accessToken = accessToken;
   }
 
   public boolean isSuccessful() {
     return successful;
   }
+
 }

--- a/oauth2-server/src/test/java/com/clouway/oauth2/IssueNewTokenForClientTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/IssueNewTokenForClientTest.java
@@ -6,6 +6,7 @@ import com.clouway.friendlyserve.testing.RsPrint;
 import com.clouway.oauth2.authorization.Authorization;
 import com.clouway.oauth2.authorization.ClientAuthorizationRepository;
 import com.clouway.oauth2.client.Client;
+import com.clouway.oauth2.token.BearerToken;
 import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.token.TokenResponse;
 import com.clouway.oauth2.token.Tokens;
@@ -20,6 +21,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.Collections;
 
+import static com.clouway.oauth2.TokenBuilder.aNewToken;
 import static com.clouway.oauth2.client.ClientBuilder.aNewClient;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -50,7 +52,7 @@ public class IssueNewTokenForClientTest {
       will(returnValue(Optional.of(new Authorization("", "", "::user_id::", "::auth_code::", Collections.<String>emptySet(), Collections.singleton("::redirect_uri::")))));
 
       oneOf(tokens).issueToken(GrantType.AUTHORIZATION_CODE, client, "::user_id::", Collections.<String>emptySet(), anyTime);
-      will(returnValue(new TokenResponse(true, "::token::", "::refresh token::", 2000L)));
+      will(returnValue(new TokenResponse(true, aNewToken().withValue("::token::").build(), "::refresh token::")));
     }});
 
     Response response = controller.execute(client, new ParamRequest(ImmutableMap.of("code", "::auth_code::", "redirect_uri", "::redirect_uri::")), anyTime);
@@ -70,7 +72,7 @@ public class IssueNewTokenForClientTest {
       will(returnValue(Optional.of(new Authorization("", "", "::user_id::", "::auth_code::", Collections.<String>emptySet(), Collections.singleton("::redirect_uri::")))));
 
       oneOf(tokens).issueToken(GrantType.AUTHORIZATION_CODE, client, "::user_id::", Collections.<String>emptySet(), anyTime);
-      will(returnValue(new TokenResponse(false, "", "", 0L)));
+      will(returnValue(new TokenResponse(false, null, "")));
     }});
 
     Response response = controller.execute(client, new ParamRequest(ImmutableMap.of("code", "::auth_code::", "redirect_uri", "::redirect_uri::")), anyTime);

--- a/oauth2-server/src/test/java/com/clouway/oauth2/RefreshTokenForClientTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/RefreshTokenForClientTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static com.clouway.oauth2.TokenBuilder.aNewToken;
 import static com.clouway.oauth2.client.ClientBuilder.aNewClient;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
@@ -38,7 +39,9 @@ public class RefreshTokenForClientTest {
 
     context.checking(new Expectations() {{
       oneOf(tokens).refreshToken("::refresh_token::", anyTime);
-      will(returnValue(new TokenResponse(true, "::access_token::", "::refresh_token::", 600L)));
+      will(returnValue(
+              new TokenResponse(true, aNewToken().withValue("::access_token::").expiresAt(anyTime.plusSeconds(600)).build(), "::refresh_token::")
+      ));
     }});
 
     Response response = action.execute(client, new ParamRequest(ImmutableMap.of("refresh_token", "::refresh_token::")), anyTime);
@@ -58,7 +61,7 @@ public class RefreshTokenForClientTest {
 
     context.checking(new Expectations() {{
       oneOf(tokens).refreshToken("::refresh_token::", anyTime);
-      will(returnValue(new TokenResponse(false, "", "", 0L)));
+      will(returnValue(new TokenResponse(false, null, "")));
     }});
 
     Response response = action.execute(client, new ParamRequest(ImmutableMap.of("refresh_token", "::refresh_token::")), anyTime);

--- a/oauth2-server/src/test/java/com/clouway/oauth2/jwt/HandleJwtTokenRequestsTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/jwt/HandleJwtTokenRequestsTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
 
+import static com.clouway.oauth2.TokenBuilder.aNewToken;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 
@@ -74,7 +75,7 @@ public class HandleJwtTokenRequestsTest {
       will(returnValue(true));
 
       oneOf(tokens).issueToken(with(any(GrantType.class)), with(any(Client.class)), with(any(String.class)), with(any(Set.class)), with(any(DateTime.class)));
-      will(returnValue(new TokenResponse(true, "::access_token::", "::refresh_token::", 1000L)));
+      will(returnValue(new TokenResponse(true, aNewToken().withValue("::access_token::").expiresAt(anyInstantTime.plusSeconds(1000)).build(), "::refresh_token::")));
     }});
 
     Response response = controller.handleAsOf(newJwtRequest(String.format("%s.%s.%s", "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9", body, signature)), anyInstantTime);
@@ -103,7 +104,7 @@ public class HandleJwtTokenRequestsTest {
       oneOf(tokens).issueToken(
               GrantType.JWT, jwtClient, "xxx@developer.com", Sets.newHashSet("CanDoX", "CanDoY"), anyInstantTime
       );
-      will(returnValue(new TokenResponse(false, "", "", 0L)));
+      will(returnValue(new TokenResponse(true, aNewToken().build(), "")));
     }});
 
     controller.handleAsOf(newJwtRequest(String.format("%s.%s.%s", "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9", body, signature), "CanDoX CanDoY"), anyInstantTime);


### PR DESCRIPTION
Access token is no longer primitive which allows removing of the TTL property as it's calculated by the BearerToken.