### PR TITLE
oauth2: added id_token to bearer token response

### DIFF
--- a/oauth2-example-app/pom.xml
+++ b/oauth2-example-app/pom.xml
@@ -93,6 +93,12 @@
       <version>1.0</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.clouway.security</groupId>
+      <artifactId>jwt-java-client-okhttp</artifactId>
+      <version>0.0.1</version>
+    </dependency>
+
     <!-- Testing Libraries-->
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/oauth2-example-app/src/main/java/com/clouway/oauth2/app/JwtClient.java
+++ b/oauth2-example-app/src/main/java/com/clouway/oauth2/app/JwtClient.java
@@ -1,0 +1,65 @@
+package com.clouway.oauth2.app;
+
+import com.clouway.oauth2.client.BearerAuthenticationInterceptor;
+import com.clouway.oauth2.client.JwtConfig;
+import com.clouway.oauth2.client.TokenSource;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+
+/**
+ * @author Vasil Mitov <v.mitov.clouway@gmail.com>
+ */
+public class JwtClient {
+  private static String key = "-----BEGIN PRIVATE KEY-----\n" +
+          "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCH/eazwg0BwuFx\n" +
+          "PmXOoauqD54ZPN+3XRF8FxrYo0XvQ8TiJAEJBJo/qjNahn4YYl/6RbP8YLHCe3nd\n" +
+          "40tf42fwvLDFBSyFjKIOOiEEilhxjVX1jPsE4fHO+gSthmyzGgjR4bPCPLCeocQj\n" +
+          "UQTguDsl2NARDWHomeC0eJgkS9cPfBdRGyIsgQWsnON+SbMd7cN9iXbIhU/TguLE\n" +
+          "aW6WAg/rGX9iMiSsl5XcW6wOGU24uRPTNIySzncLY+jEQeFmEw1g0oa7+ZKuxDce\n" +
+          "jJTzo4V0BcEKNiiZvH4Y7t/qsXiDeY13NemZVMQ/H9BIyfBpPdiTphnZEwf5XlUJ\n" +
+          "pKekD/KBAgMBAAECggEAZeFXltAIAovHbZl7mAQSoUM2BF5QlASLdtWwbSBU4l15\n" +
+          "AJpMlD74eD3AX09m5Em+8baKksa2Jadvs0X3UA0D75zNKa0on5yuQ85UshwbCmcC\n" +
+          "QQWvgQbsq00vd/i/MqaMeQCINTpWb2Ftma+24cvjtATsS/okoae2aj32bSrMIXKK\n" +
+          "V9UC2IwN5rzoJPEFQ6fPaWcTnFMOINY1UFDerVNhn7aT18ubB25N3TcQFA+IkLjZ\n" +
+          "+RXAVsDqmmdiCA0IxF18SkC22TCLvWMW8pYAYWYi9MLOCwwjUwv1C3w38qvlzfRP\n" +
+          "VDObsDgrmYA5xyJU1LIzvnaWYa+br6VmnBdCqBTTSQKBgQDzc+pkjol6qDVJb8ZD\n" +
+          "oa2mNZJCu3dNYSuB9fYGutIT8/BuBZ+qkmb54C6Ny7M0HjpxQpSOToOpH95HlznJ\n" +
+          "NLY80s76E9MdX6xFIlTpBRJnu3iPizCXRQV5C0mwleARVsk0FjE5T0XLQMp3l1bd\n" +
+          "AGMGJhM9fM0W3mx2gmTjU+DRGwKBgQCPACjFI1aFIbFtpOQtFgHtCMdymhzLVabc\n" +
+          "SyY7fnMoQiiPJMja9reFiSuJbF/BpsAxaOKEaVjivPM3arVaf3pyrqC3ZEwurfwx\n" +
+          "u+mnXhUftT8/1esZZBGhFPA321zIaDucKx7yfOgg+gRdi6r4gpYD0pQo7sco86Ve\n" +
+          "ARzhgUWgkwKBgGVsaj8gXsgZ4bFJfrjYV4bCFL/2Z7p1+/E1rhyZokGrxAOiFiWy\n" +
+          "vnHlYp+yOGNDIKfkzA0JSrKf0zPSHcHkUvO+A3qN3csD+7oFlohJk6RhptVucHzk\n" +
+          "xWXrPPTzS5kNpd8sS6+LhhEqWe8+vnJt4dNC84sPPkYDvf4VTsCiRiv3AoGAGjx1\n" +
+          "PnYVUae03eD63CrFf6+0qBoOXmAAlTpUcWXpyuEYf+rHzySk1yMrkbMIfocRi/8q\n" +
+          "UBDj9fWkye4SB+CLnq7bXcpRD99r/dP0MnjYd1DRoeyljasGcP9ec2ETzNES3rwq\n" +
+          "mWLBVAuK8X7Gh4Gt9FWWSUxFzgWluXGK0vTcyXECgYA7GyyBORukyfOb5mCrIXm5\n" +
+          "kYztpvfhglrUZ23vEzXLk+KPmDao0X3K6fv6OuvuI2oVAZ6TzTT1OlmF/elvP7JX\n" +
+          "4vlOXSxLBduB1cInuZFylB99qRmGMCBWhpIobXyRQIZWnaQnsGDfFJiBrBgzN55U\n" +
+          "UqgbFBNjeedWV+Hm6ftwxw==\n" +
+          "-----END PRIVATE KEY-----";
+
+  // JWT/Service Account Authorization
+  // OAuth2 Client Authorization -> web app -> API Gateway
+  public static void main(String[] args) {
+    JwtConfig config = new JwtConfig.Builder(
+            "xxx@apps.clouway.com",
+            "http://localhost:9002/oauth2/token",
+            key.getBytes())
+            .subject("myapp ")
+            .build();
+    TokenSource tokenSource = config.tokenSource();
+    OkHttpClient client = new OkHttpClient.Builder()
+            .addInterceptor(new BearerAuthenticationInterceptor(tokenSource))
+            .build();
+    try {
+      Response response = client.newCall(new Request.Builder().get().url("http://localhost:9002/testapi").build()).execute();
+      System.out.println(response.body().string());
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryClientRepository.java
+++ b/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryClientRepository.java
@@ -55,6 +55,12 @@ class InMemoryClientRepository implements ClientRegistry, ClientFinder, ClientKe
     return null;
   }
 
+  @Override
+  public Map<String, Block> publicCertificates() {
+    return null;
+  }
+
+
   public void registerServiceAccount(String clientEmail, String privateKeyAsPem) {
     try {
       serviceAccountKeys.put(clientEmail, pem.parse(new ByteArrayInputStream(privateKeyAsPem.getBytes())));

--- a/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryTokens.java
+++ b/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryTokens.java
@@ -65,11 +65,11 @@ class InMemoryTokens implements Tokens {
       tokens.put(newTokenValue, updatedToken);
       refreshTokenToAccessToken.put(refreshToken, newTokenValue);
 
-      return new TokenResponse(true, updatedToken, refreshToken);
+      return new TokenResponse(true, updatedToken, refreshToken,"");
 
     }
 
-    return new TokenResponse(false, null, "");
+    return new TokenResponse(false, null, "","");
   }
 
   @Override
@@ -80,7 +80,7 @@ class InMemoryTokens implements Tokens {
     BearerToken bearerToken = new BearerToken(token, GrantType.JWT, identity.id(), client.id, identity.email(), scopes, when);
     tokens.put(token, bearerToken);
 
-    return new TokenResponse(true, bearerToken, refreshTokenValue);
+    return new TokenResponse(true, bearerToken, refreshTokenValue,"");
   }
 
   @Override

--- a/oauth2-server/src/main/java/com/clouway/oauth2/BearerTokenResponse.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/BearerTokenResponse.java
@@ -14,17 +14,18 @@ import com.google.gson.JsonObject;
  */
 public class BearerTokenResponse extends RsWrap {
 
-  public BearerTokenResponse(String accessToken, Long expiresInSeconds, String refreshToken) {
-    super(new RsJson(createToken(accessToken, expiresInSeconds, refreshToken)
+  public BearerTokenResponse(String accessToken, Long expiresInSeconds, String refreshToken,String encodedIdToken) {
+    super(new RsJson(createToken(accessToken, expiresInSeconds, refreshToken,encodedIdToken)
     ));
   }
 
-  private static JsonElement createToken(String accessToken, Long expiresInSeconds, String refreshToken) {
+  private static JsonElement createToken(String accessToken, Long expiresInSeconds, String refreshToken,String encodedIdToken) {
     JsonObject o = new JsonObject();
     o.addProperty("access_token", accessToken);
     o.addProperty("token_type", "Bearer");
     o.addProperty("expires_in", expiresInSeconds);
     o.addProperty("refresh_token", refreshToken);
+    o.addProperty("id_token",encodedIdToken);
     return o;
   }
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/IssueNewTokenActivity.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/IssueNewTokenActivity.java
@@ -5,6 +5,10 @@ import com.clouway.friendlyserve.Response;
 import com.clouway.oauth2.authorization.Authorization;
 import com.clouway.oauth2.authorization.ClientAuthorizationRepository;
 import com.clouway.oauth2.client.Client;
+import com.clouway.oauth2.client.ClientKeyStore;
+import com.clouway.oauth2.jws.Pem;
+import com.clouway.oauth2.jws.Pem.Block;
+import com.clouway.oauth2.jwt.Jwt.Header;
 import com.clouway.oauth2.token.BearerToken;
 import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.token.TokenResponse;
@@ -12,21 +16,30 @@ import com.clouway.oauth2.token.Tokens;
 import com.clouway.oauth2.user.IdentityFinder;
 import com.google.common.base.Optional;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static com.clouway.oauth2.idtoken.IdTokenBuilder.newIdToken;
+import static com.clouway.oauth2.jwt.Jwt.ClaimSet.newClaimSet;
+
 /**
  * IssueNewTokenActivity is representing the activity which is performed for issuing of new token.
  *
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
 class IssueNewTokenActivity implements ClientActivity {
-
   private final Tokens tokens;
   private final IdentityFinder identityFinder;
   private final ClientAuthorizationRepository clientAuthorizationRepository;
+  private final ClientKeyStore keyStore;
 
-  IssueNewTokenActivity(Tokens tokens, IdentityFinder identityFinder, ClientAuthorizationRepository clientAuthorizationRepository) {
+  IssueNewTokenActivity(Tokens tokens, IdentityFinder identityFinder, ClientAuthorizationRepository clientAuthorizationRepository, ClientKeyStore keyStore) {
     this.tokens = tokens;
     this.identityFinder = identityFinder;
     this.clientAuthorizationRepository = clientAuthorizationRepository;
+    this.keyStore = keyStore;
   }
 
   @Override
@@ -47,6 +60,10 @@ class IssueNewTokenActivity implements ClientActivity {
     }
 
     Identity identity = possibleIdentity.get();
+    Map<String, Block> certificates = keyStore.publicCertificates();
+    String certKey = randomKey(certificates);
+    Pem.Block key = certificates.get(certKey);
+
 
     TokenResponse response = tokens.issueToken(GrantType.AUTHORIZATION_CODE, client, identity, authorization.scopes, instant);
     if (!response.isSuccessful()) {
@@ -54,7 +71,27 @@ class IssueNewTokenActivity implements ClientActivity {
     }
 
     BearerToken accessToken = response.accessToken;
+    String host = request.header("Host");
 
-    return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), response.refreshToken);
+    String idToken = newIdToken().header(new Header("RS256"))
+            .claims(newClaimSet()
+                    .iss(host)
+                    .aud(client.id)
+                    .sub(identity.id())
+                    .iat(instant.timestamp())
+                    .exp(accessToken.expirationTimestamp())
+                    .certId(certKey)
+                    .customClaims(identity.claims())
+                    .build())
+            .signWith(key)
+            .build();
+
+    return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), response.refreshToken, idToken);
+  }
+
+  private String randomKey(Map<String, Block> map) {
+    Random random = new Random();
+    List<String> certId = new ArrayList<>(map.keySet());
+    return certId.get(random.nextInt(certId.size()));
   }
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/OAuth2Config.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/OAuth2Config.java
@@ -80,6 +80,7 @@ public final class OAuth2Config {
   private final ClientAuthorizationRepository clientAuthorizationRepository;
   private final ClientKeyStore clientKeyStore;
   private final String loginPageUrl;
+
   private OAuth2Config(Builder builder) {
     this.tokens = builder.tokens;
     this.identityFinder = builder.identityFinder;

--- a/oauth2-server/src/main/java/com/clouway/oauth2/OAuth2Servlet.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/OAuth2Servlet.java
@@ -62,7 +62,8 @@ public abstract class OAuth2Servlet extends HttpServlet {
                                                             new ClientController(
                                                                     config.clientFinder(),
                                                                     new IssueNewTokenActivity(
-                                                                            config.tokens(), config.identityFinder(), config.clientAuthorizationRepository()
+                                                                            config.tokens(), config.identityFinder(), config.clientAuthorizationRepository(),
+                                                                            config.serviceAccountRepository()
                                                                     )
                                                             )
                                                     ))

--- a/oauth2-server/src/main/java/com/clouway/oauth2/RefreshTokenActivity.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/RefreshTokenActivity.java
@@ -29,6 +29,6 @@ class RefreshTokenActivity implements ClientActivity {
 
     BearerToken accessToken = response.accessToken;
 
-    return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), response.refreshToken);
+    return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), response.refreshToken,response.idToken);
   }
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/authorization/Authorization.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/authorization/Authorization.java
@@ -1,6 +1,5 @@
 package com.clouway.oauth2.authorization;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.Objects;
 import java.util.Set;

--- a/oauth2-server/src/main/java/com/clouway/oauth2/client/ClientKeyStore.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/client/ClientKeyStore.java
@@ -2,9 +2,9 @@ package com.clouway.oauth2.client;
 
 import com.clouway.oauth2.jws.Pem;
 import com.clouway.oauth2.jwt.Jwt;
-import com.clouway.oauth2.jwt.Jwt.ClaimSet;
-import com.clouway.oauth2.jwt.Jwt.Header;
 import com.google.common.base.Optional;
+
+import java.util.Map;
 
 /**
  * ClientKeyStore is a KeyStore which is responsible for retrieving of Key blocks for verifying
@@ -20,10 +20,18 @@ public interface ClientKeyStore {
   /**
    * Finds associated KEY for the provided claim set.
    *
-   * @param header the jwt header that specifies the type of the algorithm
+   * @param header   the jwt header that specifies the type of the algorithm
    * @param claimSet the claim set of which service account is requested
    * @return the key for that service account
    */
   Optional<Pem.Block> findKey(Jwt.Header header, Jwt.ClaimSet claimSet);
+
+  /**
+   * Returns all available publicCertificates used in the authorisation server
+   *
+   * @return A map containing all the publicCertificates in a pair with a string identifier as a key.
+   */
+  Map<String, Pem.Block> publicCertificates();
+
 
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/idtoken/IdTokenBuilder.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/idtoken/IdTokenBuilder.java
@@ -1,0 +1,47 @@
+package com.clouway.oauth2.idtoken;
+
+
+import com.clouway.oauth2.jws.Pem;
+import com.clouway.oauth2.jws.RsaJwsSignature;
+import com.clouway.oauth2.jwt.Jwt.ClaimSet;
+import com.clouway.oauth2.jwt.Jwt.Header;
+import com.google.common.io.BaseEncoding;
+
+/**
+ * @author Vasil Mitov <v.mitov.clouway@gmail.com>
+ */
+public class IdTokenBuilder {
+
+  private Header header;
+  private ClaimSet claims;
+  private Pem.Block key;
+
+  public static IdTokenBuilder newIdToken() {
+    return new IdTokenBuilder();
+  }
+
+  public IdTokenBuilder header(Header header) {
+    this.header = header;
+    return this;
+  }
+
+  public IdTokenBuilder claims(ClaimSet claims) {
+    this.claims = claims;
+    return this;
+  }
+
+  public IdTokenBuilder signWith(Pem.Block key) {
+    this.key = key;
+    return this;
+  }
+
+  public String build() {
+    String headerString = BaseEncoding.base64Url().omitPadding().encode(header.toString().getBytes());
+    String claimsString = BaseEncoding.base64Url().omitPadding().encode(claims.toString().getBytes());
+
+    String unsignedToken = String.format("%s.%s", headerString, claimsString);
+    RsaJwsSignature signature = new RsaJwsSignature(unsignedToken.getBytes());
+
+    return String.format("%s.%s", unsignedToken, signature.sign(unsignedToken.getBytes(), key));
+  }
+}

--- a/oauth2-server/src/main/java/com/clouway/oauth2/jws/RsaJwsSignature.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/jws/RsaJwsSignature.java
@@ -1,11 +1,16 @@
 package com.clouway.oauth2.jws;
 
-import java.io.ByteArrayInputStream;
+import com.clouway.oauth2.jws.Pem.Block;
+
 import java.security.KeyFactory;
 import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.security.Signature;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
+
+import static com.google.common.io.BaseEncoding.base64;
 
 /**
  * RsaJwsSignature is an implementation of {@link com.clouway.oauth2.jws.Signature} that uses
@@ -16,11 +21,12 @@ import java.util.Arrays;
 public class RsaJwsSignature implements com.clouway.oauth2.jws.Signature {
   private byte[] signature;
 
+
   public RsaJwsSignature(byte[] signature) {
     this.signature = signature;
   }
 
-  public boolean verify(byte[] content, Pem.Block privateKey) {
+  public boolean verifyWithPrivateKey(byte[] content, Pem.Block privateKey) {
     try {
 
       PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(privateKey.getBytes());
@@ -40,4 +46,44 @@ public class RsaJwsSignature implements com.clouway.oauth2.jws.Signature {
       return false;
     }
   }
+
+  @Override
+  public boolean verify(byte[] content, Block key) {
+    try {
+      X509EncodedKeySpec keySpec = new X509EncodedKeySpec(key.getBytes());
+      KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+      PublicKey publicKey = keyFactory.generatePublic(keySpec);
+      Signature sig = Signature.getInstance("SHA256withRSA");
+
+      sig.initVerify(publicKey);
+      sig.update(content);
+
+      return sig.verify(signature);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    return false;
+  }
+
+  @Override
+  public String sign(byte[] content, Pem.Block privateKey) {
+    try {
+      PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(privateKey.getBytes());
+      KeyFactory kf = KeyFactory.getInstance("RSA");
+      PrivateKey privKey = kf.generatePrivate(keySpec);
+
+      Signature sig = Signature.getInstance("SHA256withRSA");
+      sig.initSign(privKey);
+
+      sig.update(content);
+
+      byte[] signed = sig.sign();
+      return base64().omitPadding().encode(signed);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
+
+
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/jws/Signature.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/jws/Signature.java
@@ -1,5 +1,10 @@
 package com.clouway.oauth2.jws;
 
+import com.clouway.oauth2.jws.Pem.Block;
+
+import java.security.Key;
+import java.security.KeyPair;
+
 /**
  * Signature is representing a single JWS signature that is applied over received messages.
  * <p/>
@@ -12,10 +17,30 @@ public interface Signature {
    * Verify is verifying Signature using the provided privateKey as PEM file.
    * <p/>
    *
-   * @param content the content to be verified
+   * @param content    the content to be verified
    * @param privateKey the private key used for verifying
    * @return true if signature is
    */
-  boolean verify(byte[] content, Pem.Block privateKey);
+  boolean verifyWithPrivateKey(byte[] content, Pem.Block privateKey);
+
+  /**
+   * Verify is veryfying Signature using the provided publicKey as PEM file
+   * <p/>
+   *
+   * @param content to be verified
+   * @param key The public key to verify the content with
+   * @return
+   */
+  boolean verify(byte[] content, Block key);
+
+  /**
+   * Sign a token with a private key
+   * <p/>
+   *
+   * @param content of the token
+   * @param privateKey to sign the token with
+   * @return token signature to be added to the token header.claims
+   */
+  String sign(byte[] content, Pem.Block privateKey);
 
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/jwt/Jwt.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/jwt/Jwt.java
@@ -2,6 +2,8 @@ package com.clouway.oauth2.jwt;
 
 import com.google.common.base.MoreObjects;
 
+import java.util.Map;
+
 /**
  * Jwt stands for JSON Web Token and is the entry point of the JWT package.
  *
@@ -21,7 +23,7 @@ public final class Jwt {
     public final String alg;
 
     @SuppressWarnings("unused")
-    Header() {
+    public Header() {
       this(null);
     }
 
@@ -77,12 +79,90 @@ public final class Jwt {
      */
     public final String prn;
 
-    @SuppressWarnings("unused")
-    ClaimSet() {
-      this(null, null, null, null, null, null, null);
+    public final String certId;
+
+    public final Map<String, Object> customClaims;
+
+    public static final class Builder {
+      private String iss;
+      private String scope;
+      private String aud;
+      private Long exp;
+      private Long iat;
+      private String typ;
+      private String sub;
+      private String prn;
+      private String certId;
+      private Map<String, Object> customClaims;
+
+      private Builder() {
+      }
+
+      public ClaimSet build() {
+        return new ClaimSet(this);
+      }
+
+      public Builder iss(String iss) {
+        this.iss = iss;
+        return this;
+      }
+
+      public Builder scope(String scope) {
+        this.scope = scope;
+        return this;
+      }
+
+      public Builder aud(String aud) {
+        this.aud = aud;
+        return this;
+      }
+
+      public Builder exp(Long exp) {
+        this.exp = exp;
+        return this;
+      }
+
+      public Builder iat(Long iat) {
+        this.iat = iat;
+        return this;
+      }
+
+      public Builder typ(String typ) {
+        this.typ = typ;
+        return this;
+      }
+
+      public Builder sub(String sub) {
+        this.sub = sub;
+        return this;
+      }
+
+      public Builder prn(String prn) {
+        this.prn = prn;
+        return this;
+      }
+
+      public Builder certId(String certId) {
+        this.certId = certId;
+        return this;
+      }
+
+      public Builder customClaims(Map<String, Object> customClaims) {
+        this.customClaims = customClaims;
+        return this;
+      }
     }
 
-    public ClaimSet(String iss, String scope, String aud, Long exp, Long iat, String typ, String sub) {
+    public static Builder newClaimSet() {
+      return new Builder();
+    }
+
+    @SuppressWarnings("unused")
+    ClaimSet() {
+      this(null, null, null, null, null, null, null, null, null);
+    }
+
+    public ClaimSet(String iss, String scope, String aud, Long exp, Long iat, String typ, String sub, String certId, Map<String, Object> customClaims) {
       this.iss = iss;
       this.scope = scope;
       this.aud = aud;
@@ -91,12 +171,27 @@ public final class Jwt {
       this.typ = typ;
       this.sub = sub;
       this.prn = sub;
-
+      this.certId = certId;
+      this.customClaims = customClaims;
     }
 
     @Override
     public String toString() {
-      return MoreObjects.toStringHelper(this).add("iss", iss).add("scope", scope).add("aud", aud).add("exp", exp).add("iat", iat).add("typ", typ).toString();
+      return MoreObjects.toStringHelper(this).add("iss", iss).add("scope", scope).add("aud", aud).add("exp", exp)
+              .add("iat", iat).add("typ", typ).add("certificate_id", certId).add("custom_claims", customClaims).toString();
+    }
+
+    private ClaimSet(Builder builder) {
+      this.iss = builder.iss;
+      this.scope = builder.scope;
+      this.aud = builder.aud;
+      this.exp = builder.exp;
+      this.iat = builder.iat;
+      this.typ = builder.typ;
+      this.sub = builder.sub;
+      this.prn = builder.prn;
+      this.certId = builder.certId;
+      this.customClaims = builder.customClaims;
     }
   }
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/jwt/JwtController.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/jwt/JwtController.java
@@ -31,7 +31,7 @@ import java.util.Set;
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
-public class JwtController implements InstantaneousRequest {
+public class  JwtController implements InstantaneousRequest {
   private final Gson gson = new Gson();
 
   private final SignatureFactory signatureFactory;
@@ -84,7 +84,7 @@ public class JwtController implements InstantaneousRequest {
 
     byte[] headerAndContentAsBytes = String.format("%s.%s", parts.get(0), parts.get(1)).getBytes();
 
-    if (!optSignature.get().verify(headerAndContentAsBytes, serviceAccountKey)) {
+    if (!optSignature.get().verifyWithPrivateKey(headerAndContentAsBytes, serviceAccountKey)) {
       return OAuthError.invalidGrant();
     }
 
@@ -106,7 +106,7 @@ public class JwtController implements InstantaneousRequest {
     
     BearerToken accessToken = response.accessToken;
 
-    return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), response.refreshToken);
+    return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), response.refreshToken,response.idToken);
   }
 
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/token/TokenResponse.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/token/TokenResponse.java
@@ -13,11 +13,13 @@ public final class TokenResponse {
 
   public final BearerToken accessToken;
   public final String refreshToken;
+  public final String idToken;
 
-  public TokenResponse(boolean successful, BearerToken accessToken, String refreshToken) {
+  public TokenResponse(boolean successful, BearerToken accessToken, String refreshToken, String idToken) {
     this.successful = successful;
     this.refreshToken = refreshToken;
     this.accessToken = accessToken;
+    this.idToken = idToken;
   }
 
   public boolean isSuccessful() {

--- a/oauth2-server/src/test/java/com/clouway/oauth2/PemKeyGenerator.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/PemKeyGenerator.java
@@ -1,0 +1,41 @@
+package com.clouway.oauth2;
+
+import com.clouway.oauth2.jws.Pem;
+import com.clouway.oauth2.jws.Pem.Block;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Collections;
+
+/**
+ * @author Vasil Mitov <v.mitov.clouway@gmail.com>
+ */
+public class PemKeyGenerator {
+  private static KeyPair keyPair = getKeyPair(1024);
+
+  public static Pem.Block generatePublicKey() {
+    PublicKey publicKey = keyPair.getPublic();
+    return new Pem.Block("PUBLIC KEY", Collections.<String, String>emptyMap(), publicKey.getEncoded());
+  }
+
+  public static Pem.Block generatePrivateKey() {
+    PrivateKey privateKey = keyPair.getPrivate();
+    return new Pem.Block("PRIVATE KEY", Collections.<String, String>emptyMap(), privateKey.getEncoded());
+  }
+
+  private static KeyPair getKeyPair(Integer size) {
+    KeyPairGenerator keyGen = null;
+    try {
+      keyGen = KeyPairGenerator.getInstance("RSA");
+    } catch (NoSuchAlgorithmException e) {
+      e.printStackTrace();
+    }
+    keyGen.initialize(size);
+    return keyGen.generateKeyPair();
+  }
+}

--- a/oauth2-server/src/test/java/com/clouway/oauth2/RefreshTokenForClientTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/RefreshTokenForClientTest.java
@@ -40,7 +40,7 @@ public class RefreshTokenForClientTest {
     context.checking(new Expectations() {{
       oneOf(tokens).refreshToken("::refresh_token::", anyTime);
       will(returnValue(
-              new TokenResponse(true, aNewToken().withValue("::access_token::").expiresAt(anyTime.plusSeconds(600)).build(), "::refresh_token::")
+              new TokenResponse(true, aNewToken().withValue("::access_token::").expiresAt(anyTime.plusSeconds(600)).build(), "::refresh_token::", "encodedIdToken")
       ));
     }});
 
@@ -61,7 +61,7 @@ public class RefreshTokenForClientTest {
 
     context.checking(new Expectations() {{
       oneOf(tokens).refreshToken("::refresh_token::", anyTime);
-      will(returnValue(new TokenResponse(false, null, "")));
+      will(returnValue(new TokenResponse(false, null, "", "encodedIdToken")));
     }});
 
     Response response = action.execute(client, new ParamRequest(ImmutableMap.of("refresh_token", "::refresh_token::")), anyTime);

--- a/oauth2-server/src/test/java/com/clouway/oauth2/SerializeBearerTokensTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/SerializeBearerTokensTest.java
@@ -17,26 +17,29 @@ public class SerializeBearerTokensTest {
 
   @Test
   public void happyPath() throws IOException {
+
     String expectedResponse = "Content-Type: application/json; charset=utf-8\r\n" +
             "{\"access_token\":\"mF_9.B5f-4.1JqM\"," +
             "\"token_type\":\"Bearer\"," +
             "\"expires_in\":3600," +
-            "\"refresh_token\":" +
-            "\"tGzv3JOkF0XG5Qx2TlKWIA\"}";
+            "\"refresh_token\":\"tGzv3JOkF0XG5Qx2TlKWIA\"," +
+            "\"id_token\":\"::id token::\"}";
 
-    assertThat(contentOf(new BearerTokenResponse("mF_9.B5f-4.1JqM", 3600L, "tGzv3JOkF0XG5Qx2TlKWIA")), is(equalTo(expectedResponse)));
+    assertThat(contentOf(new BearerTokenResponse("mF_9.B5f-4.1JqM", 3600L, "tGzv3JOkF0XG5Qx2TlKWIA","::id token::")), is(equalTo(expectedResponse)));
   }
 
   @Test
   public void anotherToken() throws IOException {
+
     String expectedResponse = "Content-Type: application/json; charset=utf-8\r\n" +
             "{\"access_token\":\"::token2::\"," +
             "\"token_type\":\"Bearer\"," +
             "\"expires_in\":2400," +
             "\"refresh_token\":" +
-            "\"::refresh_token::2\"}";
+            "\"::refresh_token::2\","+
+            "\"id_token\":\"::id token::\"}";
 
-    assertThat(contentOf(new BearerTokenResponse("::token2::", 2400L, "::refresh_token::2")), is(equalTo(expectedResponse)));
+    assertThat(contentOf(new BearerTokenResponse("::token2::", 2400L, "::refresh_token::2","::id token::")), is(equalTo(expectedResponse)));
   }
 
   private String contentOf(Response response) throws IOException {

--- a/oauth2-server/src/test/java/com/clouway/oauth2/VerifyTokenTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/VerifyTokenTest.java
@@ -1,0 +1,77 @@
+package com.clouway.oauth2;
+
+import com.clouway.oauth2.jws.Pem;
+import com.clouway.oauth2.jws.Pem.Block;
+import com.clouway.oauth2.jws.RsaJwsSignature;
+import com.clouway.oauth2.jwt.Jwt.Header;
+import com.google.common.io.BaseEncoding;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static com.clouway.oauth2.PemKeyGenerator.generatePrivateKey;
+import static com.clouway.oauth2.PemKeyGenerator.generatePublicKey;
+import static com.clouway.oauth2.idtoken.IdTokenBuilder.newIdToken;
+import static com.clouway.oauth2.jwt.Jwt.ClaimSet.newClaimSet;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+/**
+ * @author Vasil Mitov <v.mitov.clouway@gmail.com>
+ */
+public class VerifyTokenTest {
+  private Map<String, Object> customClaims = new LinkedHashMap<String, Object>() {{
+    put("name", "Foo");
+    put("given_name", "John");
+    put("family_name", "Doe");
+    put("custom_claims", Collections.emptyList());
+  }};
+
+  private final Pem.Block privateKey = generatePrivateKey();
+  private final String token = newIdToken().header(new Header("RS256"))
+          .claims(newClaimSet()
+                  .iss("provider.somedomain.com")
+                  .sub("10769150350006150715113082367")
+                  .iat(123456789L)
+                  .customClaims(customClaims)
+                  .build())
+          .signWith(privateKey)
+          .build();
+
+  @Test
+  public void tokenVerifiedWithPrivateKey() throws Exception {
+    String parts[] = token.split("\\.");
+    byte[] signatureValue = BaseEncoding.base64().decode(parts[2]);
+    RsaJwsSignature signature = new RsaJwsSignature(signatureValue);
+    String value = String.format("%s.%s", parts[0], parts[1]);
+
+    boolean tokenVerified = signature.verifyWithPrivateKey(value.getBytes(), privateKey);
+    assertThat(tokenVerified, is(true));
+  }
+
+  @Test
+  public void tokenVerifiedWithPublicKey() throws Exception {
+    byte[] signatureValue = BaseEncoding.base64().decode(token.split("\\.")[2]);
+    RsaJwsSignature signature = new RsaJwsSignature(signatureValue);
+
+    String tokenWithoutSignature = token.split("\\.")[0] + "." + token.split("\\.")[1];
+    Block publicKey = generatePublicKey();
+
+    boolean tokenVerified = signature.verify(tokenWithoutSignature.getBytes(), publicKey);
+    assertThat(tokenVerified, is(true));
+  }
+
+  @Test
+  public void invalidTokenTest() throws Exception {
+    //Signature from another token
+    byte[] signatureValue = BaseEncoding.base64().decode("TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ");
+    RsaJwsSignature signature = new RsaJwsSignature(signatureValue);
+
+    String tokenWithoutSignature = token.split("\\.")[0] + "." + token.split("\\.")[1];
+
+    boolean tokenVerified = signature.verifyWithPrivateKey(tokenWithoutSignature.getBytes(), privateKey);
+    assertThat(tokenVerified, is(false));
+  }
+}

--- a/oauth2-server/src/test/java/com/clouway/oauth2/jws/VerifySignaturesWithRsaTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/jws/VerifySignaturesWithRsaTest.java
@@ -50,7 +50,7 @@ public class VerifySignaturesWithRsaTest {
     byte[] signatureValue = BaseEncoding.base64Url().decode("WBAzzss3J8Ea6-xxOCVS2OZ2HoqpiLdfCLhIJEevaPck377qTpiM__lHta_S8dSCuTl5FjREqixIiwGrJVJEIkfExUwS5YWekdJRniSKdqLjmXussePaCSgco3reJDqNcRCGiv9DSLH0GfZFdv11Ik5nyaHjNnS4ykEi76guaY8-T3uVFjOH4e2o8Wm0vBbq9hzo9UHdgnsI2BLrzDVoydGWM7uZW8MQNKTuGWY_Ywyj1hilr9rw4yy2FvBe7G-56qaq8--IlVNZ6ocJX2dYhZPqDtZUYwLRqwFyM_F53Kt81I8Qht6HBgH-fgrfbd7Ms67BeLGsupFvuM9sF-hGOQ");
 
     boolean isSignedWithThatKey = new RsaJwsSignature(signatureValue)
-            .verify(String.format("%s.%s", "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9", "eyJpc3MiOiJ4eHhAZGV2ZWxvcGVyLmNvbSIsInNjb3BlIjoidGVzdDEgdGVzdDIiLCJhdWQiOiJodHRwOi8vbG9jYWxob3N0OjkwMDIvb2F1dGgyL3Rva2VuIiwiZXhwIjoxNDYxMjM4OTQ4LCJpYXQiOjE0NjEyMzUzNDgsInN1YiI6InVzZXJAZXhhbXBsZS5jb20iLCJwcm4iOiJ1c2VyQGV4YW1wbGUuY29tIn0").getBytes(), privateKey);
+            .verifyWithPrivateKey(String.format("%s.%s", "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9", "eyJpc3MiOiJ4eHhAZGV2ZWxvcGVyLmNvbSIsInNjb3BlIjoidGVzdDEgdGVzdDIiLCJhdWQiOiJodHRwOi8vbG9jYWxob3N0OjkwMDIvb2F1dGgyL3Rva2VuIiwiZXhwIjoxNDYxMjM4OTQ4LCJpYXQiOjE0NjEyMzUzNDgsInN1YiI6InVzZXJAZXhhbXBsZS5jb20iLCJwcm4iOiJ1c2VyQGV4YW1wbGUuY29tIn0").getBytes(), privateKey);
 
     assertThat(isSignedWithThatKey, is(equalTo(true)));
   }
@@ -58,10 +58,10 @@ public class VerifySignaturesWithRsaTest {
   @Test
   public void signatureIsNotMatching() throws IOException {
     Pem.Block privateKey = new Pem().parse(new ByteArrayInputStream(privateKeyPem.getBytes()));
-    byte[] signatureValue = BaseEncoding.base64Url().decode("WBAzzss3J8Ea6-xxOCVS2OZ2HoqpiLdfCLhIJEevaPck377qTpiM__lHta_S8dSCuTl5FjREqixIiwGrJVJEIkfExUwS5YWekdJRniSKdqLjmXussePaCSgco3reJDqNcRCGiv9DSLH0GfZFdv11Ik5nyaHjNnS4ykEi76guaY8-T3uVFjOH4e2o8Wm0vBbq9hzo9UHdgnsI2BLrzDVoydGWM7uZW8MQNKTuGWY_Ywyj1hilr9rw4yy2FvBe7G-56qaq8--IlVNZ6ocJX2dYhZPqDtZUYwLRqwFyM_F53Kt81I8Qht6HBgH-fgrfbd7Ms67BeLGsupFvuM9sF-hGOQ");
+     byte[] signatureValue = BaseEncoding.base64Url().decode("WBAzzss3J8Ea6-xxOCVS2OZ2HoqpiLdfCLhIJEevaPck377qTpiM__lHta_S8dSCuTl5FjREqixIiwGrJVJEIkfExUwS5YWekdJRniSKdqLjmXussePaCSgco3reJDqNcRCGiv9DSLH0GfZFdv11Ik5nyaHjNnS4ykEi76guaY8-T3uVFjOH4e2o8Wm0vBbq9hzo9UHdgnsI2BLrzDVoydGWM7uZW8MQNKTuGWY_Ywyj1hilr9rw4yy2FvBe7G-56qaq8--IlVNZ6ocJX2dYhZPqDtZUYwLRqwFyM_F53Kt81I8Qht6HBgH-fgrfbd7Ms67BeLGsupFvuM9sF-hGOQ");
 
     boolean isSignedWithThatKey = new RsaJwsSignature(signatureValue)
-            .verify(String.format("%s.%s", "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXJJJJ", "eyJpc3MiOiJ4eHhAZGV2ZWxvcGVyLmNvbSIsInNjb3BlIjoidGVzdDEgdGVzdDIiLCJhdWQiOiJodHRwOi8vbG9jYWxob3N0OjkwMDIvb2F1dGgyL3Rva2VuIiwiZXhwIjoxNDYxMjM4OTQ4LCJpYXQiOjE0NjEyMzUzNDgsInN1YiI6InVzZXJAZXhhbXBsZS5jb20iLCJwcm4iOiJ1c2VyQGV4YW1wbGUuY29tIn0").getBytes(), privateKey);
+            .verifyWithPrivateKey(String.format("%s.%s", "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXJJJJ", "eyJpc3MiOiJ4eHhAZGV2ZWxvcGVyLmNvbSIsInNjb3BlIjoidGVzdDEgdGVzdDIiLCJhdWQiOiJodHRwOi8vbG9jYWxob3N0OjkwMDIvb2F1dGgyL3Rva2VuIiwiZXhwIjoxNDYxMjM4OTQ4LCJpYXQiOjE0NjEyMzUzNDgsInN1YiI6InVzZXJAZXhhbXBsZS5jb20iLCJwcm4iOiJ1c2VyQGV4YW1wbGUuY29tIn0").getBytes(), privateKey);
 
     assertThat(isSignedWithThatKey, is(equalTo(false)));
   }

--- a/oauth2-server/src/test/java/com/clouway/oauth2/jwt/HandleJwtTokenRequestsTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/jwt/HandleJwtTokenRequestsTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Set;
 
 import static com.clouway.oauth2.IdentityBuilder.aNewIdentity;
@@ -78,14 +77,14 @@ public class HandleJwtTokenRequestsTest {
       oneOf(signatureFactory).createSignature(with(any(byte[].class)), with(any(Jwt.Header.class)));
       will(returnValue(Optional.of(anySignatureThatWillVerifies)));
 
-      oneOf(anySignatureThatWillVerifies).verify(with(any(byte[].class)), with(any(Pem.Block.class)));
+      oneOf(anySignatureThatWillVerifies).verifyWithPrivateKey(with(any(byte[].class)), with(any(Pem.Block.class)));
       will(returnValue(true));
 
       oneOf(identityFinder).findIdentity(with(any(String.class)), with(any(GrantType.class)), with(any(DateTime.class)));
       will(returnValue(Optional.of(aNewIdentity().build())));
 
       oneOf(tokens).issueToken(with(any(GrantType.class)), with(any(Client.class)), with(any(Identity.class)), with(any(Set.class)), with(any(DateTime.class)));
-      will(returnValue(new TokenResponse(true, aNewToken().withValue("::access_token::").expiresAt(anyInstantTime.plusSeconds(1000)).build(), "::refresh_token::")));
+      will(returnValue(new TokenResponse(true, aNewToken().withValue("::access_token::").expiresAt(anyInstantTime.plusSeconds(1000)).build(), "::refresh_token::","")));
     }});
 
     Response response = controller.handleAsOf(newJwtRequest(String.format("%s.%s.%s", "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9", body, signature)), anyInstantTime);
@@ -110,7 +109,7 @@ public class HandleJwtTokenRequestsTest {
       oneOf(signatureFactory).createSignature(with(any(byte[].class)), with(any(Jwt.Header.class)));
       will(returnValue(Optional.of(anySignatureThatWillVerifies)));
 
-      oneOf(anySignatureThatWillVerifies).verify(with(any(byte[].class)), with(any(Pem.Block.class)));
+      oneOf(anySignatureThatWillVerifies).verifyWithPrivateKey(with(any(byte[].class)), with(any(Pem.Block.class)));
       will(returnValue(true));
 
       oneOf(identityFinder).findIdentity(with(any(String.class)), with(any(GrantType.class)), with(any(DateTime.class)));
@@ -119,7 +118,7 @@ public class HandleJwtTokenRequestsTest {
       oneOf(tokens).issueToken(
               GrantType.JWT, jwtClient, identity, Sets.newHashSet("CanDoX", "CanDoY"), anyInstantTime
       );
-      will(returnValue(new TokenResponse(true, aNewToken().build(), "")));
+      will(returnValue(new TokenResponse(true, aNewToken().build(), "","")));
     }});
 
     controller.handleAsOf(newJwtRequest(String.format("%s.%s.%s", "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9", body, signature), "CanDoX CanDoY"), anyInstantTime);


### PR DESCRIPTION
Added an id_token field to the response field. For the moment it is in String format, but I was wondering would it be a good idea to make an IdToken object with a method to be able to encode/decode it in base64 format. As I understand Tokens are made and added to the response from the repositories with the interface Tokens.
PS: I do not have rights to assign reviewers nor put labels
related #12
