### PR TITLE
oauth2-server: improved client repository

### DIFF
--- a/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryClientRepository.java
+++ b/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryClientRepository.java
@@ -1,6 +1,7 @@
 package com.clouway.oauth2.exampleapp.storage;
 
 import com.clouway.oauth2.client.Client;
+import com.clouway.oauth2.client.ClientRegistrationRequest;
 import com.clouway.oauth2.client.ClientRepository;
 import com.clouway.oauth2.client.ClientKeyStore;
 import com.clouway.oauth2.jws.Pem;
@@ -14,6 +15,7 @@ import com.google.inject.Inject;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * @author Ivan Stefanov <ivan.stefanov@clouway.com>
@@ -28,8 +30,12 @@ class InMemoryClientRepository implements ClientRepository, ClientKeyStore {
   }
 
   @Override
-  public void register(Client client) {
+  public Client register(ClientRegistrationRequest request) {
+    String randomId = UUID.randomUUID().toString();
+    Client client =
+            new Client(randomId, request.secret, request.description, request.redirectURLs);
     clients.put(client.id, client);
+    return client;
   }
 
   @Override

--- a/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryModule.java
+++ b/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryModule.java
@@ -2,6 +2,7 @@ package com.clouway.oauth2.exampleapp.storage;
 
 import com.clouway.oauth2.Duration;
 
+import com.clouway.oauth2.client.ClientRegistrationRequest;
 import com.clouway.oauth2.exampleapp.ResourceOwnerStore;
 import com.clouway.oauth2.authorization.ClientAuthorizationRepository;
 import com.clouway.oauth2.client.Client;
@@ -36,7 +37,7 @@ public class InMemoryModule extends AbstractModule {
     bind(SessionSecurity.class).toInstance(resourceOwnerRepository);
 
     InMemoryClientRepository clientRepository = new InMemoryClientRepository();
-    clientRepository.register(new Client("fe72722a40de846e03865cb3b582aed57841ac71", "857613db7b18232c72a5093ad19dbc6df74a139e", "test", Collections.singleton("http://localhost:8080/oauth/callback")));
+    clientRepository.register(new ClientRegistrationRequest("857613db7b18232c72a5093ad19dbc6df74a139e", "test", Collections.singleton("http://localhost:8080/oauth/callback")));
     clientRepository.registerServiceAccount("xxx@apps.clouway.com", "-----BEGIN PRIVATE KEY-----\n" +
             "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCH/eazwg0BwuFx\n" +
             "PmXOoauqD54ZPN+3XRF8FxrYo0XvQ8TiJAEJBJo/qjNahn4YYl/6RbP8YLHCe3nd\n" +

--- a/oauth2-example-app/src/test/java/com/clouway/oauth2/exampleapp/ClientRepositoryContractTest.java
+++ b/oauth2-example-app/src/test/java/com/clouway/oauth2/exampleapp/ClientRepositoryContractTest.java
@@ -1,7 +1,9 @@
 package com.clouway.oauth2.exampleapp;
 
 import com.clouway.oauth2.client.Client;
+import com.clouway.oauth2.client.ClientRegistrationRequest;
 import com.clouway.oauth2.client.ClientRepository;
+import com.clouway.oauth2.exampleapp.storage.InMemoryClientRepositoryTest;
 import com.google.common.base.Optional;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,22 +17,21 @@ import static org.junit.Assert.assertFalse;
 /**
  * @author Mihail Lesikov (mlesikov@gmail.com)
  */
-public abstract class ClientRepositoryContractTest {
+public class ClientRepositoryContractTest {
 
   private ClientRepository repository;
 
   @Before
   public void setUp() throws Exception {
-    repository = createRepository();
-
+    repository = new InMemoryClientRepositoryTest();
   }
 
   @Test
   public void findById() throws Exception {
-    Client client = new Client("id1", "secret1", "description1", Collections.singleton("redirectURI1"));
-    repository.register(client);
+    ClientRegistrationRequest request = new ClientRegistrationRequest("secret1", "description1", Collections.singleton("redirectURI1"));
+    Client client = repository.register(request);
 
-    Optional<Client> actualClient = repository.findById("id1");
+    Optional<Client> actualClient = repository.findById(client.id);
 
     assertThat(actualClient.get(), is(client));
   }
@@ -41,7 +42,4 @@ public abstract class ClientRepositoryContractTest {
 
     assertFalse(client.isPresent());
   }
-
- public abstract ClientRepository createRepository();
-
 }

--- a/oauth2-example-app/src/test/java/com/clouway/oauth2/exampleapp/storage/InMemoryClientRepositoryTest.java
+++ b/oauth2-example-app/src/test/java/com/clouway/oauth2/exampleapp/storage/InMemoryClientRepositoryTest.java
@@ -1,17 +1,26 @@
 package com.clouway.oauth2.exampleapp.storage;
 
+import com.clouway.oauth2.client.Client;
+import com.clouway.oauth2.client.ClientAlreadyExistsException;
+import com.clouway.oauth2.client.ClientRegistrationRequest;
 import com.clouway.oauth2.client.ClientRepository;
 import com.clouway.oauth2.exampleapp.ClientRepositoryContractTest;
+import com.google.common.base.Optional;
 
 /**
  * @author Ivan Stefanov <ivan.stefanov@clouway.com>
  */
-public class InMemoryClientRepositoryTest extends ClientRepositoryContractTest {
+public class InMemoryClientRepositoryTest implements ClientRepository {
 
   private InMemoryClientRepository repository = new InMemoryClientRepository();
 
   @Override
-  public ClientRepository createRepository() {
-    return repository;
+  public Client register(ClientRegistrationRequest request) throws ClientAlreadyExistsException {
+    return repository.register(request);
+  }
+
+  @Override
+  public Optional<Client> findById(String id) {
+    return repository.findById(id);
   }
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/client/ClientRegistrationRequest.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/client/ClientRegistrationRequest.java
@@ -1,0 +1,15 @@
+package com.clouway.oauth2.client;
+
+import java.util.Set;
+
+public class ClientRegistrationRequest {
+  public final String secret;
+  public final String description;
+  public final Set<String> redirectURLs;
+
+  public ClientRegistrationRequest(String secret, String description, Set<String> redirectURLs) {
+    this.secret = secret;
+    this.description = description;
+    this.redirectURLs = redirectURLs;
+  }
+}

--- a/oauth2-server/src/main/java/com/clouway/oauth2/client/ClientRepository.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/client/ClientRepository.java
@@ -7,7 +7,7 @@ import com.google.common.base.Optional;
  */
 public interface ClientRepository {
 
-  void register(Client client) throws ClientAlreadyExistsException;
+  Client register(ClientRegistrationRequest request) throws ClientAlreadyExistsException;
 
   Optional<Client> findById(String id);
 }


### PR DESCRIPTION
no longer client repositry accepts Client Object, instead of that
it accept ClientRegistrationRequest that gives info about client
that will be stored
PS: I think  about that it can be added a seccond method that accepts
client object so that user can use both with Client or ClientRegistrationRequest

Related to #32