### PR TITLE
oauth2-server: remove id_token property from TokenResponse

### DIFF
--- a/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryTokens.java
+++ b/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryTokens.java
@@ -9,7 +9,6 @@ import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.token.TokenGenerator;
 import com.clouway.oauth2.token.TokenResponse;
 import com.clouway.oauth2.token.Tokens;
-import com.clouway.oauth2.user.IdentityFinder;
 import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
@@ -65,11 +64,11 @@ class InMemoryTokens implements Tokens {
       tokens.put(newTokenValue, updatedToken);
       refreshTokenToAccessToken.put(refreshToken, newTokenValue);
 
-      return new TokenResponse(true, updatedToken, refreshToken,"");
+      return new TokenResponse(true, updatedToken, refreshToken);
 
     }
 
-    return new TokenResponse(false, null, "","");
+    return new TokenResponse(false, null, "");
   }
 
   @Override
@@ -80,7 +79,7 @@ class InMemoryTokens implements Tokens {
     BearerToken bearerToken = new BearerToken(token, GrantType.JWT, identity.id(), client.id, identity.email(), scopes, when);
     tokens.put(token, bearerToken);
 
-    return new TokenResponse(true, bearerToken, refreshTokenValue,"");
+    return new TokenResponse(true, bearerToken, refreshTokenValue);
   }
 
   @Override

--- a/oauth2-server/src/main/java/com/clouway/oauth2/BearerTokenResponse.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/BearerTokenResponse.java
@@ -2,6 +2,7 @@ package com.clouway.oauth2;
 
 import com.clouway.friendlyserve.RsJson;
 import com.clouway.friendlyserve.RsWrap;
+import com.google.common.base.Strings;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
@@ -14,18 +15,26 @@ import com.google.gson.JsonObject;
  */
 public class BearerTokenResponse extends RsWrap {
 
-  public BearerTokenResponse(String accessToken, Long expiresInSeconds, String refreshToken,String encodedIdToken) {
-    super(new RsJson(createToken(accessToken, expiresInSeconds, refreshToken,encodedIdToken)
+  public BearerTokenResponse(String accessToken, Long expiresInSeconds, String refreshToken, String encodedIdToken) {
+    super(new RsJson(createToken(accessToken, expiresInSeconds, refreshToken, encodedIdToken)
     ));
   }
 
-  private static JsonElement createToken(String accessToken, Long expiresInSeconds, String refreshToken,String encodedIdToken) {
+  public BearerTokenResponse(String accessToken, Long expiresInSeconds, String refreshToken) {
+    this(accessToken, expiresInSeconds, refreshToken, "");
+  }
+
+  private static JsonElement createToken(String accessToken, Long expiresInSeconds, String refreshToken, String encodedIdToken) {
     JsonObject o = new JsonObject();
     o.addProperty("access_token", accessToken);
     o.addProperty("token_type", "Bearer");
     o.addProperty("expires_in", expiresInSeconds);
     o.addProperty("refresh_token", refreshToken);
-    o.addProperty("id_token",encodedIdToken);
+
+    if (!Strings.isNullOrEmpty(encodedIdToken)) {
+      o.addProperty("id_token", encodedIdToken);
+    }
+    
     return o;
   }
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/RefreshTokenActivity.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/RefreshTokenActivity.java
@@ -29,6 +29,6 @@ class RefreshTokenActivity implements ClientActivity {
 
     BearerToken accessToken = response.accessToken;
 
-    return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), response.refreshToken,response.idToken);
+    return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), response.refreshToken);
   }
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/jwt/JwtController.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/jwt/JwtController.java
@@ -31,7 +31,7 @@ import java.util.Set;
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
-public class  JwtController implements InstantaneousRequest {
+public class JwtController implements InstantaneousRequest {
   private final Gson gson = new Gson();
 
   private final SignatureFactory signatureFactory;
@@ -105,8 +105,8 @@ public class  JwtController implements InstantaneousRequest {
     }
     
     BearerToken accessToken = response.accessToken;
-
-    return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), response.refreshToken,response.idToken);
+    
+    return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), response.refreshToken);
   }
 
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/token/TokenResponse.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/token/TokenResponse.java
@@ -13,13 +13,11 @@ public final class TokenResponse {
 
   public final BearerToken accessToken;
   public final String refreshToken;
-  public final String idToken;
 
-  public TokenResponse(boolean successful, BearerToken accessToken, String refreshToken, String idToken) {
+  public TokenResponse(boolean successful, BearerToken accessToken, String refreshToken) {
     this.successful = successful;
     this.refreshToken = refreshToken;
     this.accessToken = accessToken;
-    this.idToken = idToken;
   }
 
   public boolean isSuccessful() {

--- a/oauth2-server/src/test/java/com/clouway/oauth2/IssueNewTokenForClientTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/IssueNewTokenForClientTest.java
@@ -61,7 +61,7 @@ public class IssueNewTokenForClientTest {
       will(returnValue(Optional.of(new Authorization("", "", "::user_id::", "::auth_code::", Collections.<String>emptySet(), Collections.singleton("::redirect_uri::")))));
 
       oneOf(tokens).issueToken(GrantType.AUTHORIZATION_CODE, client, identity, Collections.<String>emptySet(), anyTime);
-      will(returnValue(new TokenResponse(true, aNewToken().withValue("::token::").build(), "::refresh token::", "::id_token::")));
+      will(returnValue(new TokenResponse(true, aNewToken().withValue("::token::").build(), "::refresh token::")));
 
       oneOf(identityFinder).findIdentity(with(any(String.class)), with(any(GrantType.class)), with(any(DateTime.class)));
       will(returnValue(Optional.of(identity)));
@@ -90,7 +90,7 @@ public class IssueNewTokenForClientTest {
       will(returnValue(Optional.of(new Authorization("", "", "::user_id::", "::auth_code::", Collections.<String>emptySet(), Collections.singleton("::redirect_uri::")))));
 
       oneOf(tokens).issueToken(GrantType.AUTHORIZATION_CODE, client, identity, Collections.<String>emptySet(), anyTime);
-      will(returnValue(new TokenResponse(false, null, "", "::id_token::")));
+      will(returnValue(new TokenResponse(false, null, "")));
 
       oneOf(identityFinder).findIdentity(with(any(String.class)), with(any(GrantType.class)), with(any(DateTime.class)));
       will(returnValue(Optional.of(identity)));

--- a/oauth2-server/src/test/java/com/clouway/oauth2/RefreshTokenForClientTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/RefreshTokenForClientTest.java
@@ -40,7 +40,7 @@ public class RefreshTokenForClientTest {
     context.checking(new Expectations() {{
       oneOf(tokens).refreshToken("::refresh_token::", anyTime);
       will(returnValue(
-              new TokenResponse(true, aNewToken().withValue("::access_token::").expiresAt(anyTime.plusSeconds(600)).build(), "::refresh_token::", "encodedIdToken")
+              new TokenResponse(true, aNewToken().withValue("::access_token::").expiresAt(anyTime.plusSeconds(600)).build(), "::refresh_token::")
       ));
     }});
 
@@ -61,7 +61,7 @@ public class RefreshTokenForClientTest {
 
     context.checking(new Expectations() {{
       oneOf(tokens).refreshToken("::refresh_token::", anyTime);
-      will(returnValue(new TokenResponse(false, null, "", "encodedIdToken")));
+      will(returnValue(new TokenResponse(false, null, "")));
     }});
 
     Response response = action.execute(client, new ParamRequest(ImmutableMap.of("refresh_token", "::refresh_token::")), anyTime);

--- a/oauth2-server/src/test/java/com/clouway/oauth2/jwt/HandleJwtTokenRequestsTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/jwt/HandleJwtTokenRequestsTest.java
@@ -84,7 +84,7 @@ public class HandleJwtTokenRequestsTest {
       will(returnValue(Optional.of(aNewIdentity().build())));
 
       oneOf(tokens).issueToken(with(any(GrantType.class)), with(any(Client.class)), with(any(Identity.class)), with(any(Set.class)), with(any(DateTime.class)));
-      will(returnValue(new TokenResponse(true, aNewToken().withValue("::access_token::").expiresAt(anyInstantTime.plusSeconds(1000)).build(), "::refresh_token::","")));
+      will(returnValue(new TokenResponse(true, aNewToken().withValue("::access_token::").expiresAt(anyInstantTime.plusSeconds(1000)).build(), "::refresh_token::")));
     }});
 
     Response response = controller.handleAsOf(newJwtRequest(String.format("%s.%s.%s", "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9", body, signature)), anyInstantTime);
@@ -118,7 +118,7 @@ public class HandleJwtTokenRequestsTest {
       oneOf(tokens).issueToken(
               GrantType.JWT, jwtClient, identity, Sets.newHashSet("CanDoX", "CanDoY"), anyInstantTime
       );
-      will(returnValue(new TokenResponse(true, aNewToken().build(), "","")));
+      will(returnValue(new TokenResponse(true, aNewToken().build(), "")));
     }});
 
     controller.handleAsOf(newJwtRequest(String.format("%s.%s.%s", "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9", body, signature), "CanDoX CanDoY"), anyInstantTime);


### PR DESCRIPTION
IdToken property is removed from the TokenResponse as it's generation should be responsibility of the library and not of the client apps which are using it.

Still refresh token handler and JWT handler are not using it as expected, but it will be added in following PR.

Related with #43 