### PR TITLE
oauth2-server: split verify and sign functionality

### DIFF
--- a/oauth2-server/src/main/java/com/clouway/oauth2/idtoken/IdTokenBuilder.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/idtoken/IdTokenBuilder.java
@@ -2,10 +2,12 @@ package com.clouway.oauth2.idtoken;
 
 
 import com.clouway.oauth2.jws.Pem;
-import com.clouway.oauth2.jws.RsaJwsSignature;
+import com.clouway.oauth2.jws.RsaJwsSigner;
 import com.clouway.oauth2.jwt.Jwt.ClaimSet;
 import com.clouway.oauth2.jwt.Jwt.Header;
 import com.google.common.io.BaseEncoding;
+
+import static com.clouway.oauth2.jws.RsaJwsSigner.sign;
 
 /**
  * @author Vasil Mitov <v.mitov.clouway@gmail.com>
@@ -40,8 +42,7 @@ public class IdTokenBuilder {
     String claimsString = BaseEncoding.base64Url().omitPadding().encode(claims.toString().getBytes());
 
     String unsignedToken = String.format("%s.%s", headerString, claimsString);
-    RsaJwsSignature signature = new RsaJwsSignature(unsignedToken.getBytes());
 
-    return String.format("%s.%s", unsignedToken, signature.sign(unsignedToken.getBytes(), key));
+    return String.format("%s.%s", unsignedToken, RsaJwsSigner.sign(unsignedToken.getBytes(), key));
   }
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/jws/RsaJwsSignature.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/jws/RsaJwsSignature.java
@@ -64,26 +64,4 @@ public class RsaJwsSignature implements com.clouway.oauth2.jws.Signature {
     }
     return false;
   }
-
-  @Override
-  public String sign(byte[] content, Pem.Block privateKey) {
-    try {
-      PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(privateKey.getBytes());
-      KeyFactory kf = KeyFactory.getInstance("RSA");
-      PrivateKey privKey = kf.generatePrivate(keySpec);
-
-      Signature sig = Signature.getInstance("SHA256withRSA");
-      sig.initSign(privKey);
-
-      sig.update(content);
-
-      byte[] signed = sig.sign();
-      return base64().omitPadding().encode(signed);
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-    return null;
-  }
-
-
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/jws/RsaJwsSigner.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/jws/RsaJwsSigner.java
@@ -1,0 +1,42 @@
+package com.clouway.oauth2.jws;
+
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.impl.crypto.RsaSigner;
+
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+
+import static com.google.common.io.BaseEncoding.base64;
+
+/**
+ * @author Vasil Mitov <v.mitov.clouway@gmail.com>
+ */
+public class RsaJwsSigner {
+  private static final SignatureAlgorithm rsaAlgorithm = SignatureAlgorithm.forName("RS256");
+
+  public static String sign(byte[] content, Pem.Block privateKey) {
+    PrivateKey prKey = parsePem(privateKey);
+    RsaSigner rsaSigner = new RsaSigner(rsaAlgorithm, prKey);
+    byte[] signedContent = rsaSigner.sign(content);
+    return tokenSignature(signedContent);
+  }
+
+  private static PrivateKey parsePem(Pem.Block privateKey) {
+    try {
+      PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(privateKey.getBytes());
+      KeyFactory kf = KeyFactory.getInstance("RSA");
+      return kf.generatePrivate(keySpec);
+    } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
+
+  private static String tokenSignature(byte[] content) {
+    return base64().omitPadding().encode(content);
+  }
+}

--- a/oauth2-server/src/main/java/com/clouway/oauth2/jws/Signature.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/jws/Signature.java
@@ -33,14 +33,4 @@ public interface Signature {
    */
   boolean verify(byte[] content, Block key);
 
-  /**
-   * Sign a token with a private key
-   * <p/>
-   *
-   * @param content of the token
-   * @param privateKey to sign the token with
-   * @return token signature to be added to the token header.claims
-   */
-  String sign(byte[] content, Pem.Block privateKey);
-
 }


### PR DESCRIPTION
Added a RsaJwsSigner with a static method sign for RSA signing with
Pem.Blocks and removed the signing functionality from RsaJwsSignature, which now only verifies the tokens.
related #48 