### PR TITLE
oauth2-server/api: make AuthorizedClientActivity private

### DIFF
--- a/oauth2-server/src/main/java/com/clouway/oauth2/AuthorizedClientActivity.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/AuthorizedClientActivity.java
@@ -2,7 +2,6 @@ package com.clouway.oauth2;
 
 import com.clouway.friendlyserve.Request;
 import com.clouway.friendlyserve.Response;
-import com.clouway.oauth2.authorization.Authorization;
 import com.clouway.oauth2.client.Client;
 
 import java.util.Set;
@@ -12,7 +11,7 @@ import java.util.Set;
  *
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
-public interface AuthorizedClientActivity {
+interface AuthorizedClientActivity {
 
   /**
    * Handles client request of authorized client and returns response.


### PR DESCRIPTION
AuthorizedClientActivity interface is now private and is not accessible from outside. 