### PR TITLE
oauth2-example-app: find jwt key using iss

### DIFF
--- a/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryClientRepository.java
+++ b/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryClientRepository.java
@@ -52,7 +52,7 @@ class InMemoryClientRepository implements ClientRegistry, ClientFinder, ClientKe
 
   @Override
   public Optional<Block> findKey(Header header, ClaimSet claimSet) {
-    return null;
+    return Optional.fromNullable(serviceAccountKeys.get(claimSet.iss));
   }
 
   @Override


### PR DESCRIPTION
A lookup for the JWT key is now performed by the iss claim in the InMemoryCleintRepository.