### PR TITLE
oauth2-server/id_token: minor changes satisfying specifications.

### DIFF
--- a/oauth2-server/src/test/java/VerifyingJjwtTokensTest.java
+++ b/oauth2-server/src/test/java/VerifyingJjwtTokensTest.java
@@ -3,8 +3,8 @@ import com.clouway.oauth2.jws.Pem;
 import com.clouway.oauth2.jws.Pem.Block;
 import com.clouway.oauth2.jws.ReadPemFilesTest;
 import com.clouway.oauth2.jws.RsaJwsSignature;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.BaseEncoding;
-import com.google.gson.JsonObject;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import org.junit.Test;
@@ -14,8 +14,8 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
-import java.util.Collections;
 import java.util.Date;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -30,16 +30,24 @@ public class VerifyingJjwtTokensTest {
     Pem.Block block = pem.parse(ReadPemFilesTest.class.getResourceAsStream("secret.pem"));
 
     Identity identity = new Identity("123", "Pojo", "Foo", "Bar",
-            "example@email.com", "", Collections.EMPTY_MAP);
+            "example@email.com", "", ImmutableMap.<String, Object>of("customerId", "::customer Id::",
+            "customerName", "::customer name::", "isAdmin", false));
+
+    Map<String, Object> claims = ImmutableMap.<String, Object>builder()
+            .put("iss", "example.host")
+            .put("aud", "123")
+            .put("sub", identity.id())
+            .put("iat", new Date())
+            .put("exp", new Date())
+            .put("name", identity.name())
+            .put("email", identity.email())
+            .put("given_name", identity.givenName())
+            .put("family_name", identity.familyName())
+            .putAll(identity.claims()).build();
 
     String idToken = Jwts.builder()
             .setHeaderParam("cid", "certKeyIdentifier")
-            .setIssuer("host.app@example.com")
-            .setAudience("aud")
-            .setSubject(identity.id())
-            .setIssuedAt(new Date())
-            .setExpiration(new Date())
-            .claim("identity", new JsonObject().toString())
+            .setClaims(claims)
             .signWith(SignatureAlgorithm.RS256, getPrivateKey(block))
             .compact();
 
@@ -56,18 +64,16 @@ public class VerifyingJjwtTokensTest {
   public void tokenIsNotValidTest() throws Exception {
     Pem pem = new Pem();
     Pem.Block block = pem.parse(ReadPemFilesTest.class.getResourceAsStream("secret.pem"));
-
-    Identity identity = new Identity("123", "Pojos", "Foos", "Bars",
-            "examples@email.com", "", Collections.EMPTY_MAP);
+    Map<String, Object> claims = ImmutableMap.<String, Object>builder()
+            .put("iss", "example.host")
+            .put("aud", "123")
+            .put("sub", "::subject::")
+            .put("iat", new Date())
+            .put("exp", new Date()).build();
 
     String idToken = Jwts.builder()
             .setHeaderParam("cid", "certKeyIdentifiers")
-            .setIssuer("anotherHost.app@example.com")
-            .setAudience("aud")
-            .setSubject(identity.id())
-            .setIssuedAt(new Date())
-            .setExpiration(new Date())
-            .claim("identity", new JsonObject().toString())
+            .setClaims(claims)
             .signWith(SignatureAlgorithm.RS256, getPrivateKey(block))
             .compact();
 

--- a/oauth2-server/src/test/java/com/clouway/oauth2/IssueNewTokenForClientTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/IssueNewTokenForClientTest.java
@@ -53,7 +53,7 @@ public class IssueNewTokenForClientTest {
       oneOf(keyStore).privateCertificates();
       will(returnValue(Collections.singletonMap("53r7IfiCaT3", generatePrivateKey())));
 
-      oneOf(tokens).issueToken(with(any(GrantType.class)), with(any(Client.class)), with(any(Identity.class)), with(any(Set.class)), with(any(DateTime.class)));
+        oneOf(tokens).issueToken(with(any(GrantType.class)), with(any(Client.class)), with(any(Identity.class)), with(any(Set.class)), with(any(DateTime.class)));
       will(returnValue(new TokenResponse(true, aNewToken().withValue("::token::").build(), "::refresh token::")));
     }});
 


### PR DESCRIPTION
Changes have been applied in IssueNewTokenActivity to the generated id_token claims. Now identity is provided as separate claims properly suiting specifications of https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32.
The chosen private claims are named "_private_claims" to try and avoid name collisions. 
