### PR TITLE
oauth2-server/id_token: change iat and exp back to long

### DIFF
--- a/oauth2-server/src/main/java/com/clouway/oauth2/IssueNewTokenActivity.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/IssueNewTokenActivity.java
@@ -60,8 +60,8 @@ class IssueNewTokenActivity implements AuthorizedClientActivity {
       claims.put("iss", host);
       claims.put("aud", client.id);
       claims.put("sub", identity.id());
-      claims.put("iat", (instant.timestamp() / 1000));
-      claims.put("exp", accessToken.ttlSeconds(instant));
+      claims.put("iat", (instant.timestamp()));
+      claims.put("exp", accessToken.expirationTimestamp());
       claims.put("name", identity.name());
       claims.put("email", identity.email());
       claims.put("given_name", identity.givenName());


### PR DESCRIPTION
Changed back iat and exp to milliseconds as JJWT doesnt veryfy it upon testing it on another project. Token is said to have expired on the first of January 1970. 