### PR TITLE
oauth2-server/id_token: exp and iat change

### DIFF
--- a/oauth2-server/src/main/java/com/clouway/oauth2/IssueNewTokenActivity.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/IssueNewTokenActivity.java
@@ -19,6 +19,7 @@ import java.security.PrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,8 +61,6 @@ class IssueNewTokenActivity implements AuthorizedClientActivity {
       claims.put("iss", host);
       claims.put("aud", client.id);
       claims.put("sub", identity.id());
-      claims.put("iat", (instant.timestamp()));
-      claims.put("exp", accessToken.expirationTimestamp());
       claims.put("name", identity.name());
       claims.put("email", identity.email());
       claims.put("given_name", identity.givenName());
@@ -71,6 +70,8 @@ class IssueNewTokenActivity implements AuthorizedClientActivity {
       idToken = Jwts.builder()
               .setHeaderParam("cid", certKey)//CertificateId - the ID of the certificate that the token was signed with.
               .setClaims(claims)
+              .setIssuedAt(new Date(instant.timestamp()))
+              .setExpiration(new Date(accessToken.expirationTimestamp()))
               .signWith(SignatureAlgorithm.RS256, parsePem(key))
               .compact();
     }


### PR DESCRIPTION
Another change regarding iat and exp. After looking around in the JJWT library I saw that the methods for setting iat and exp requier a Date format. I think it is better to let the library do the transformation and add it through it's methods setIssuedAt and setExparation. I have tested around with it and the format that it creates is in proper seconds.