### PR TITLE
oauth2-server: support scopes in token responses

### DIFF
--- a/oauth2-server/src/main/java/com/clouway/oauth2/BearerTokenResponse.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/BearerTokenResponse.java
@@ -2,9 +2,12 @@ package com.clouway.oauth2;
 
 import com.clouway.friendlyserve.RsJson;
 import com.clouway.friendlyserve.RsWrap;
+import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+
+import java.util.Set;
 
 /**
  * BearerTokenResponse is representing the response which is returned by the OAuth Server when token is generated.
@@ -15,26 +18,30 @@ import com.google.gson.JsonObject;
  */
 public class BearerTokenResponse extends RsWrap {
 
-  public BearerTokenResponse(String accessToken, Long expiresInSeconds, String refreshToken, String encodedIdToken) {
-    super(new RsJson(createToken(accessToken, expiresInSeconds, refreshToken, encodedIdToken)
-    ));
+  public BearerTokenResponse(String accessToken, Long expiresInSeconds, Set<String> scopes, String refreshToken, String encodedIdToken) {
+    super(new RsJson(createToken(accessToken, expiresInSeconds, scopes, refreshToken, encodedIdToken)));
   }
 
-  public BearerTokenResponse(String accessToken, Long expiresInSeconds, String refreshToken) {
-    this(accessToken, expiresInSeconds, refreshToken, "");
+  public BearerTokenResponse(String accessToken, Long expiresInSeconds, Set<String> scopes, String refreshToken) {
+    this(accessToken, expiresInSeconds, scopes, refreshToken, "");
   }
 
-  private static JsonElement createToken(String accessToken, Long expiresInSeconds, String refreshToken, String encodedIdToken) {
+  private static JsonElement createToken(String accessToken, Long expiresInSeconds, Set<String> scopes, String refreshToken, String encodedIdToken) {
     JsonObject o = new JsonObject();
     o.addProperty("access_token", accessToken);
     o.addProperty("token_type", "Bearer");
     o.addProperty("expires_in", expiresInSeconds);
+
+    if (!scopes.isEmpty()) {
+      o.addProperty("scope", Joiner.on(" ").join(scopes));
+    }
+
     o.addProperty("refresh_token", refreshToken);
 
     if (!Strings.isNullOrEmpty(encodedIdToken)) {
       o.addProperty("id_token", encodedIdToken);
     }
-    
+
     return o;
   }
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/IssueNewTokenActivity.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/IssueNewTokenActivity.java
@@ -75,7 +75,7 @@ class IssueNewTokenActivity implements AuthorizedClientActivity {
               .signWith(SignatureAlgorithm.RS256, parsePem(key))
               .compact();
     }
-    return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), response.refreshToken, idToken);
+    return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), accessToken.scopes, response.refreshToken, idToken);
   }
 
   private String randomKey(Map<String, Block> map) {

--- a/oauth2-server/src/main/java/com/clouway/oauth2/RefreshTokenActivity.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/RefreshTokenActivity.java
@@ -29,6 +29,6 @@ class RefreshTokenActivity implements ClientActivity {
 
     BearerToken accessToken = response.accessToken;
 
-    return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), response.refreshToken);
+    return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), response.accessToken.scopes, response.refreshToken);
   }
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/jwt/JwtController.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/jwt/JwtController.java
@@ -106,7 +106,7 @@ public class JwtController implements InstantaneousRequest {
     
     BearerToken accessToken = response.accessToken;
     
-    return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), response.refreshToken);
+    return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), accessToken.scopes, response.refreshToken);
   }
 
 }

--- a/oauth2-server/src/test/java/com/clouway/oauth2/SerializeBearerTokensTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/SerializeBearerTokensTest.java
@@ -2,13 +2,16 @@ package com.clouway.oauth2;
 
 import com.clouway.friendlyserve.Response;
 import com.clouway.friendlyserve.testing.RsPrint;
+import com.google.common.collect.Sets;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)
@@ -22,10 +25,11 @@ public class SerializeBearerTokensTest {
             "{\"access_token\":\"mF_9.B5f-4.1JqM\"," +
             "\"token_type\":\"Bearer\"," +
             "\"expires_in\":3600," +
+            "\"scope\":\"scope1 scope2\"," +
             "\"refresh_token\":\"tGzv3JOkF0XG5Qx2TlKWIA\"," +
             "\"id_token\":\"::id token::\"}";
 
-    assertThat(contentOf(new BearerTokenResponse("mF_9.B5f-4.1JqM", 3600L, "tGzv3JOkF0XG5Qx2TlKWIA","::id token::")), is(equalTo(expectedResponse)));
+    assertThat(contentOf(new BearerTokenResponse("mF_9.B5f-4.1JqM", 3600L, Sets.newTreeSet(Arrays.asList("scope1", "scope2")), "tGzv3JOkF0XG5Qx2TlKWIA", "::id token::")), is(equalTo(expectedResponse)));
   }
 
   @Test
@@ -36,10 +40,10 @@ public class SerializeBearerTokensTest {
             "\"token_type\":\"Bearer\"," +
             "\"expires_in\":2400," +
             "\"refresh_token\":" +
-            "\"::refresh_token::2\","+
+            "\"::refresh_token::2\"," +
             "\"id_token\":\"::id token::\"}";
 
-    assertThat(contentOf(new BearerTokenResponse("::token2::", 2400L, "::refresh_token::2","::id token::")), is(equalTo(expectedResponse)));
+    assertThat(contentOf(new BearerTokenResponse("::token2::", 2400L, Collections.<String>emptySet(), "::refresh_token::2", "::id token::")), is(equalTo(expectedResponse)));
   }
 
   private String contentOf(Response response) throws IOException {


### PR DESCRIPTION
The scopes which are allowed for resource owners are now returned in Token responses either when token is issued for the first time or when a refresh token is used for issuing of a new access token.