### PR TITLE
oauth2-server: provide custom request params to the access token

### DIFF
--- a/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryTokens.java
+++ b/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryTokens.java
@@ -40,7 +40,7 @@ class InMemoryTokens implements Tokens {
         //remove the current token
         tokens.remove(tokenValue);
         // new instance
-        BearerToken updatedToken = new BearerToken(token.value, token.grantType, token.identityId, token.clientId, token.email, Collections.<String>emptySet(), instant);
+        BearerToken updatedToken = new BearerToken(token.value, token.grantType, token.identityId, token.clientId, token.email, Collections.<String>emptySet(), instant, Maps.<String, String>newHashMap());
         //add the new token
         tokens.put(tokenValue, updatedToken);
 
@@ -59,7 +59,7 @@ class InMemoryTokens implements Tokens {
       tokens.remove(accessToken);
 
       String newTokenValue = tokenGenerator.generate();
-      BearerToken updatedToken = new BearerToken(newTokenValue, oldToken.grantType, oldToken.identityId, oldToken.clientId, oldToken.email, Collections.<String>emptySet(), instant);
+      BearerToken updatedToken = new BearerToken(newTokenValue, oldToken.grantType, oldToken.identityId, oldToken.clientId, oldToken.email, Collections.<String>emptySet(), instant, oldToken.params);
 
       tokens.put(newTokenValue, updatedToken);
       refreshTokenToAccessToken.put(refreshToken, newTokenValue);
@@ -72,11 +72,11 @@ class InMemoryTokens implements Tokens {
   }
 
   @Override
-  public TokenResponse issueToken(GrantType grantType, Client client, Identity identity, Set<String> scopes, DateTime when) {
+  public TokenResponse issueToken(GrantType grantType, Client client, Identity identity, Set<String> scopes, DateTime when, Map<String, String> params) {
     String token = tokenGenerator.generate();
     String refreshTokenValue = tokenGenerator.generate();
 
-    BearerToken bearerToken = new BearerToken(token, GrantType.JWT, identity.id(), client.id, identity.email(), scopes, when);
+    BearerToken bearerToken = new BearerToken(token, GrantType.JWT, identity.id(), client.id, identity.email(), scopes, when, params);
     tokens.put(token, bearerToken);
 
     return new TokenResponse(true, bearerToken, refreshTokenValue);

--- a/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryUserRepository.java
+++ b/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryUserRepository.java
@@ -11,6 +11,7 @@ import com.clouway.oauth2.user.User;
 import com.google.common.base.Optional;
 
 import java.util.Collections;
+import java.util.Map;
 
 /**
  * @author Mihail Lesikov (mlesikov@gmail.com)
@@ -29,7 +30,7 @@ class InMemoryUserRepository implements IdentityFinder, ResourceOwnerIdentityFin
   }
 
   @Override
-  public Optional<Identity> findIdentity(String identityId, GrantType grantType, DateTime instantTime) {
+  public Optional<Identity> findIdentity(String identityId, GrantType grantType, DateTime instantTime, Map<String, String> params) {
     if (grantType == GrantType.AUTHORIZATION_CODE) {
       return Optional.of(new Identity("testUserID", "testUser", "test User", "User Family", "test@clouway.com", null, Collections.<String, Object>emptyMap()));
     } else {

--- a/oauth2-server/src/main/java/com/clouway/oauth2/AuthCodeAuthorization.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/AuthCodeAuthorization.java
@@ -7,7 +7,10 @@ import com.clouway.oauth2.authorization.ClientAuthorizationRepository;
 import com.clouway.oauth2.client.Client;
 import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.user.IdentityFinder;
+import com.clouway.oauth2.util.Params;
 import com.google.common.base.Optional;
+
+import java.util.Map;
 
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)
@@ -18,7 +21,7 @@ class AuthCodeAuthorization implements ClientActivity {
   private final IdentityFinder identityFinder;
   private final AuthorizedClientActivity authorizedClientActivity;
 
-  AuthCodeAuthorization(ClientAuthorizationRepository clientAuthorizationRepository, IdentityFinder identityFinder,  AuthorizedClientActivity authorizedClientActivity) {
+  AuthCodeAuthorization(ClientAuthorizationRepository clientAuthorizationRepository, IdentityFinder identityFinder, AuthorizedClientActivity authorizedClientActivity) {
     this.clientAuthorizationRepository = clientAuthorizationRepository;
     this.identityFinder = identityFinder;
     this.authorizedClientActivity = authorizedClientActivity;
@@ -36,12 +39,14 @@ class AuthCodeAuthorization implements ClientActivity {
 
     Authorization authorization = possibleAuthorization.get();
 
-    Optional<Identity> possibleIdentity = identityFinder.findIdentity(authorization.identityId, GrantType.AUTHORIZATION_CODE, instant);
+    Map<String, String> params  = new Params().parse(request, "code");
+
+    Optional<Identity> possibleIdentity = identityFinder.findIdentity(authorization.identityId, GrantType.AUTHORIZATION_CODE, instant, params);
     if (!possibleIdentity.isPresent()) {
       return OAuthError.invalidGrant("identity was not found");
     }
-    
+
     Identity identity = possibleIdentity.get();
-    return authorizedClientActivity.execute(client, identity, authorization.scopes, request, instant);
+    return authorizedClientActivity.execute(client, identity, authorization.scopes, request, instant, params);
   }
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/AuthorizedClientActivity.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/AuthorizedClientActivity.java
@@ -4,6 +4,7 @@ import com.clouway.friendlyserve.Request;
 import com.clouway.friendlyserve.Response;
 import com.clouway.oauth2.client.Client;
 
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -19,7 +20,8 @@ interface AuthorizedClientActivity {
    * @param client  the client of which request will be handled
    * @param request the request
    * @param instant the time of which client was requested access
+   * @param params
    * @return the response
    */
-  Response execute(Client client, Identity identity, Set<String> scopes, Request request, DateTime instant);
+  Response execute(Client client, Identity identity, Set<String> scopes, Request request, DateTime instant, Map<String, String> params);
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/IssueNewTokenActivity.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/IssueNewTokenActivity.java
@@ -10,6 +10,7 @@ import com.clouway.oauth2.token.TokenResponse;
 import com.clouway.oauth2.token.Tokens;
 import com.google.common.base.Optional;
 
+import java.util.Map;
 import java.util.Set;
 
 
@@ -28,8 +29,8 @@ class IssueNewTokenActivity implements AuthorizedClientActivity {
   }
 
   @Override
-  public Response execute(Client client, Identity identity, Set<String> scopes, Request request, DateTime instant) {
-    TokenResponse response = tokens.issueToken(GrantType.AUTHORIZATION_CODE, client, identity, scopes, instant);
+  public Response execute(Client client, Identity identity, Set<String> scopes, Request request, DateTime instant, Map<String, String> params) {
+    TokenResponse response = tokens.issueToken(GrantType.AUTHORIZATION_CODE, client, identity, scopes, instant, params);
     if (!response.isSuccessful()) {
       return OAuthError.invalidRequest("Token cannot be issued.");
     }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/TokenInfoController.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/TokenInfoController.java
@@ -9,7 +9,10 @@ import com.clouway.oauth2.token.Tokens;
 import com.clouway.oauth2.user.IdentityFinder;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
+import com.google.common.collect.Maps;
 import com.google.gson.JsonObject;
+
+import java.util.Map;
 
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)
@@ -35,7 +38,8 @@ class TokenInfoController implements InstantaneousRequest {
     }
 
     BearerToken token = possibleToken.get();
-    Optional<Identity> possibleIdentity = identityFinder.findIdentity(token.identityId, token.grantType, instantTime);
+    Map<String, String> params = token.params != null ? token.params : Maps.<String, String>newHashMap();
+    Optional<Identity> possibleIdentity = identityFinder.findIdentity(token.identityId, token.grantType, instantTime, params);
     Identity identity = possibleIdentity.get();
     String host = request.header("Host");
     Optional<String> possibleIdToken = idIdTokenFactory.create(host, token.clientId, identity,

--- a/oauth2-server/src/main/java/com/clouway/oauth2/UserInfoController.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/UserInfoController.java
@@ -36,7 +36,7 @@ class UserInfoController implements InstantaneousRequest {
 
     BearerToken token = possibleTokenResponse.get();
 
-    Optional<Identity> possibleIdentityResponse = identityFinder.findIdentity(token.identityId, token.grantType, instantTime);
+    Optional<Identity> possibleIdentityResponse = identityFinder.findIdentity(token.identityId, token.grantType, instantTime, token.params);
     if (!possibleIdentityResponse.isPresent()) {
       return OAuthError.unknownClient();
     }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/token/BearerToken.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/token/BearerToken.java
@@ -4,6 +4,7 @@ import com.clouway.oauth2.DateTime;
 import com.google.common.base.Objects;
 
 import java.io.Serializable;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -15,14 +16,15 @@ public final class BearerToken implements Serializable {
   public final String identityId;
   public final String clientId;
   public final String email;
+  public final Map<String, String> params;
   public final Set<String> scopes;
   private final DateTime expiresAt;
 
   public BearerToken() {
-    this(null, null, null, null, null, null, null);
+    this(null, null, null, null, null, null, null, null);
   }
 
-  public BearerToken(String value, GrantType grantType, String identityId, String clientId, String email, Set<String> scopes, DateTime expiresAt) {
+  public BearerToken(String value, GrantType grantType, String identityId, String clientId, String email, Set<String> scopes, DateTime expiresAt, Map<String, String> params) {
     this.value = value;
     this.grantType = grantType;
     this.identityId = identityId;
@@ -30,6 +32,7 @@ public final class BearerToken implements Serializable {
     this.email = email;
     this.scopes = scopes;
     this.expiresAt = expiresAt;
+    this.params = params;
   }
 
   /**

--- a/oauth2-server/src/main/java/com/clouway/oauth2/token/Tokens.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/token/Tokens.java
@@ -5,6 +5,7 @@ import com.clouway.oauth2.Identity;
 import com.clouway.oauth2.client.Client;
 import com.google.common.base.Optional;
 
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -39,9 +40,10 @@ public interface Tokens {
    * @param identity   the identity for which token was issued
    * @param scopes     requested scopes
    * @param when       the requested time on which it should be issued
+   * @param params
    * @return the newly issued token
    */
-  TokenResponse issueToken(GrantType grantType, Client client, Identity identity, Set<String> scopes, DateTime when);
+  TokenResponse issueToken(GrantType grantType, Client client, Identity identity, Set<String> scopes, DateTime when, Map<String, String> params);
 
   /**
    * Revokes token from repository.

--- a/oauth2-server/src/main/java/com/clouway/oauth2/user/IdentityFinder.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/user/IdentityFinder.java
@@ -5,6 +5,8 @@ import com.clouway.oauth2.Identity;
 import com.clouway.oauth2.token.GrantType;
 import com.google.common.base.Optional;
 
+import java.util.Map;
+
 /**
  * IdentityFinder is finding the Identity of the request.
  *
@@ -18,7 +20,8 @@ public interface IdentityFinder {
    * @param identityId  the identityId of the Resource Owner.
    * @param grantType   the grant type that was acknowledged
    * @param instantTime the time on which it was requested
+   * @param params
    * @return the associated identity by that id or absent value if it's not available.
    */
-  Optional<Identity> findIdentity(String identityId, GrantType grantType, DateTime instantTime);
+  Optional<Identity> findIdentity(String identityId, GrantType grantType, DateTime instantTime, Map<String, String> params);
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/util/Params.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/util/Params.java
@@ -1,0 +1,33 @@
+package com.clouway.oauth2.util;
+
+import com.clouway.friendlyserve.Request;
+import com.clouway.friendlyserve.RequestExt;
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Mihail Lesikov (mlesikov@gmail.com)
+ */
+public class Params {
+  public Map<String, String> parse(Request request, String... exclusions) {
+
+    RequestExt req = (RequestExt) request;
+
+    List<String> exclusionsList = Arrays.asList(exclusions);
+
+    Map<String, String> params = Maps.newHashMap();
+
+    for (String key : req.params().keySet()) {
+      String value = request.param(key) == null ? "" : request.param(key);
+      if (!Strings.isNullOrEmpty(value) && !exclusionsList.contains(key)) {
+        params.put(key, value);
+      }
+    }
+
+    return params;
+  }
+}

--- a/oauth2-server/src/test/java/com/clouway/oauth2/AuthorizeClientWithAuthCodeTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/AuthorizeClientWithAuthCodeTest.java
@@ -3,7 +3,6 @@ package com.clouway.oauth2;
 import com.clouway.friendlyserve.Request;
 import com.clouway.friendlyserve.Response;
 import com.clouway.friendlyserve.RsText;
-import com.clouway.friendlyserve.testing.ParamRequest;
 import com.clouway.friendlyserve.testing.RsPrint;
 import com.clouway.oauth2.authorization.Authorization;
 import com.clouway.oauth2.authorization.ClientAuthorizationRepository;
@@ -11,13 +10,15 @@ import com.clouway.oauth2.client.Client;
 import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.user.IdentityFinder;
 import com.google.common.base.Optional;
+import com.google.common.collect.Maps;
 import org.jmock.Expectations;
 import org.jmock.integration.junit4.JUnitRuleMockery;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.Collections;
+import java.util.HashMap;
 
+import static com.clouway.friendlyserve.testing.FakeRequest.aNewRequest;
 import static com.clouway.oauth2.IdentityBuilder.aNewIdentity;
 import static com.clouway.oauth2.authorization.AuthorizationBuilder.newAuthorization;
 import static com.clouway.oauth2.client.ClientBuilder.aNewClient;
@@ -47,16 +48,16 @@ public class AuthorizeClientWithAuthCodeTest {
     final Authorization anyAuth = newAuthorization().build();
     final Identity identity = aNewIdentity().withId("::user_id::").build();
 
-    final Request request = new ParamRequest(Collections.singletonMap("code", "::any code::"));
+    final Request request = aNewRequest().param("code", "::any code::").build();
 
     context.checking(new Expectations() {{
       oneOf(repository).findAuthorization(with(any(Client.class)), with(any(String.class)), with(any(DateTime.class)));
       will(returnValue(Optional.of(anyAuth)));
 
-      oneOf(identityFinder).findIdentity(with(any(String.class)), with(any(GrantType.class)), with(any(DateTime.class)));
+      oneOf(identityFinder).findIdentity(with(any(String.class)), with(any(GrantType.class)), with(any(DateTime.class)), with(Maps.<String, String>newHashMap()));
       will(returnValue(Optional.of(identity)));
 
-      oneOf(clientActivity).execute(anyClient, identity, anyAuth.scopes, request, anyInstantTime);
+      oneOf(clientActivity).execute(anyClient, identity, anyAuth.scopes, request, anyInstantTime, Maps.<String, String>newHashMap());
       will(returnValue(new RsText("::response::")));
 
     }});
@@ -72,7 +73,7 @@ public class AuthorizeClientWithAuthCodeTest {
     final Client anyClient = aNewClient().build();
     final DateTime anyInstantTime = new DateTime();
 
-    final Request request = new ParamRequest(Collections.singletonMap("code", "::any code::"));
+    final Request request = aNewRequest().param("code", "::any code::").build();
 
     context.checking(new Expectations() {{
       oneOf(repository).findAuthorization(with(any(Client.class)), with(any(String.class)), with(any(DateTime.class)));
@@ -90,13 +91,13 @@ public class AuthorizeClientWithAuthCodeTest {
     final DateTime anyInstantTime = new DateTime();
     final Authorization anyAuth = newAuthorization().build();
 
-    final Request request = new ParamRequest(Collections.singletonMap("code", "::any code::"));
+    final Request request = aNewRequest().param("code", "::any code::").build();
 
     context.checking(new Expectations() {{
       oneOf(repository).findAuthorization(with(any(Client.class)), with(any(String.class)), with(any(DateTime.class)));
       will(returnValue(Optional.of(anyAuth)));
 
-      oneOf(identityFinder).findIdentity(with(any(String.class)), with(any(GrantType.class)), with(any(DateTime.class)));
+      oneOf(identityFinder).findIdentity(with(any(String.class)), with(any(GrantType.class)), with(any(DateTime.class)), with(Maps.<String, String>newHashMap()));
       will(returnValue(Optional.absent()));
     }});
 
@@ -115,7 +116,7 @@ public class AuthorizeClientWithAuthCodeTest {
       will(returnValue(Optional.absent()));
     }});
 
-    authCodeAuthorization.execute(anyClient, new ParamRequest(Collections.singletonMap("code", "::any code::")), anyInstantTime);
+    authCodeAuthorization.execute(anyClient, aNewRequest().param("code", "::any code::").build(), anyInstantTime);
   }
 
   @Test
@@ -128,10 +129,13 @@ public class AuthorizeClientWithAuthCodeTest {
       oneOf(repository).findAuthorization(with(any(Client.class)), with(any(String.class)), with(any(DateTime.class)));
       will(returnValue(Optional.of(anyAuth)));
 
-      oneOf(identityFinder).findIdentity(anyAuth.identityId, GrantType.AUTHORIZATION_CODE, anyInstantTime);
+      HashMap<String, String> params = Maps.<String, String>newHashMap();
+      params.put("index", "1");
+      oneOf(identityFinder).findIdentity(anyAuth.identityId, GrantType.AUTHORIZATION_CODE, anyInstantTime, params);
       will(returnValue(Optional.absent()));
     }});
 
-    authCodeAuthorization.execute(anyClient, new ParamRequest(Collections.singletonMap("code", "::any code::")), anyInstantTime);
+
+    authCodeAuthorization.execute(anyClient, aNewRequest().param("code", "::any code::").param("index", "1").build(), anyInstantTime);
   }
 }

--- a/oauth2-server/src/test/java/com/clouway/oauth2/BearerTokenBuilder.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/BearerTokenBuilder.java
@@ -4,6 +4,7 @@ import com.clouway.oauth2.token.BearerToken;
 import com.clouway.oauth2.token.GrantType;
 
 import java.util.Collections;
+import java.util.Map;
 
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)
@@ -13,11 +14,12 @@ public class BearerTokenBuilder {
   public static BearerTokenBuilder aNewToken() {
     return new BearerTokenBuilder();
   }
-  
+
   private String clientId = "";
   private DateTime expiresAt = new DateTime();
   private String value;
   private String email = "";
+  private Map<String, String> params;
 
   public BearerTokenBuilder withValue(String value) {
     this.value = value;
@@ -34,8 +36,13 @@ public class BearerTokenBuilder {
     return this;
   }
 
+  public BearerTokenBuilder params(Map<String, String> params) {
+    this.params = params;
+    return this;
+  }
+
   public BearerToken build() {
-    return new BearerToken(value, GrantType.AUTHORIZATION_CODE, "", clientId, email, Collections.<String>emptySet(), expiresAt);
+    return new BearerToken(value, GrantType.AUTHORIZATION_CODE, "", clientId, email, Collections.<String>emptySet(), expiresAt, params);
   }
 
   public BearerTokenBuilder forClient(String clientId) {

--- a/oauth2-server/src/test/java/com/clouway/oauth2/IssueNewTokenForClientTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/IssueNewTokenForClientTest.java
@@ -11,6 +11,7 @@ import com.clouway.oauth2.token.IdTokenFactory;
 import com.clouway.oauth2.token.TokenResponse;
 import com.clouway.oauth2.token.Tokens;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import org.jmock.Expectations;
 import org.jmock.integration.junit4.JUnitRuleMockery;
 import org.junit.Rule;
@@ -62,11 +63,11 @@ public class IssueNewTokenForClientTest {
               with(any(Long.class)), with(any(DateTime.class)));
       will(returnValue(Optional.of("::base64.encoded.idToken::")));
 
-      oneOf(tokens).issueToken(with(any(GrantType.class)), with(any(Client.class)), with(any(Identity.class)), with(any(Set.class)), with(any(DateTime.class)));
+      oneOf(tokens).issueToken(with(any(GrantType.class)), with(any(Client.class)), with(any(Identity.class)), with(any(Set.class)), with(any(DateTime.class)), with(ImmutableMap.of("::index::", "::1::")));
       will(returnValue(new TokenResponse(true, aNewToken().withValue("::token::").build(), "::refresh token::")));
     }});
 
-    Response response = controller.execute(aNewClient().withId("::client id::").build(), identity, anyAuhtorization.scopes, request, anyTime);
+    Response response = controller.execute(aNewClient().withId("::client id::").build(), identity, anyAuhtorization.scopes, request, anyTime, ImmutableMap.of("::index::", "::1::"));
     String body = new RsPrint(response).printBody();
 
     assertThat(body, containsString("id_token"));
@@ -89,11 +90,11 @@ public class IssueNewTokenForClientTest {
               with(any(Long.class)), with(any(DateTime.class)));
       will(returnValue(Optional.absent()));
 
-      oneOf(tokens).issueToken(with(any(GrantType.class)), with(any(Client.class)), with(any(Identity.class)), with(any(Set.class)), with(any(DateTime.class)));
+      oneOf(tokens).issueToken(with(any(GrantType.class)), with(any(Client.class)), with(any(Identity.class)), with(any(Set.class)), with(any(DateTime.class)), with(ImmutableMap.of("::index::", "::1::")));
       will(returnValue(new TokenResponse(true, aNewToken().withValue("::token::").build(), "::refresh token::")));
     }});
 
-    Response response = controller.execute(aNewClient().withId("::client id::").build(), identity, anyAuhtorization.scopes, request, anyTime);
+    Response response = controller.execute(aNewClient().withId("::client id::").build(), identity, anyAuhtorization.scopes, request, anyTime, ImmutableMap.of("::index::", "::1::"));
     String body = new RsPrint(response).printBody();
 
     assertThat(body, not(containsString("id_token")));
@@ -108,11 +109,11 @@ public class IssueNewTokenForClientTest {
     final Identity identity = aNewIdentity().withId("::user_id::").build();
 
     context.checking(new Expectations() {{
-      oneOf(tokens).issueToken(with(any(GrantType.class)), with(any(Client.class)), with(any(Identity.class)), with(any(Set.class)), with(any(DateTime.class)));
+      oneOf(tokens).issueToken(with(any(GrantType.class)), with(any(Client.class)), with(any(Identity.class)), with(any(Set.class)), with(any(DateTime.class)), with(ImmutableMap.of("::index::", "::1::")));
       will(returnValue(new TokenResponse(false, null, "")));
     }});
 
-    Response response = controller.execute(client, identity, Collections.<String>emptySet(), new ParamRequest(Collections.<String, String>emptyMap()), anyTime);
+    Response response = controller.execute(client, identity, Collections.<String>emptySet(), new ParamRequest(Collections.<String, String>emptyMap()), anyTime, ImmutableMap.of("::index::", "::1::"));
     String body = new RsPrint(response).printBody();
 
     assertThat(response.status().code, is(HttpURLConnection.HTTP_BAD_REQUEST));
@@ -127,11 +128,11 @@ public class IssueNewTokenForClientTest {
     final Authorization authorization = newAuthorization().build();
 
     context.checking(new Expectations() {{
-      oneOf(tokens).issueToken(GrantType.AUTHORIZATION_CODE, client, identity, authorization.scopes, anyTime);
+      oneOf(tokens).issueToken(GrantType.AUTHORIZATION_CODE, client, identity, authorization.scopes, anyTime, ImmutableMap.of("::index::", "::1::"));
       will(returnValue(new TokenResponse(false, null, "")));
     }});
 
-    controller.execute(client, identity, authorization.scopes, new ParamRequest(Collections.<String, String>emptyMap()), anyTime);
+    controller.execute(client, identity, authorization.scopes, new ParamRequest(Collections.<String, String>emptyMap()), anyTime, ImmutableMap.of("::index::", "::1::"));
   }
 
 }

--- a/oauth2-server/src/test/java/com/clouway/oauth2/ResourceOwnerClientAuthorizationTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/ResourceOwnerClientAuthorizationTest.java
@@ -1,8 +1,8 @@
 package com.clouway.oauth2;
 
+import com.clouway.friendlyserve.Request;
 import com.clouway.friendlyserve.Response;
 import com.clouway.friendlyserve.Status;
-import com.clouway.friendlyserve.testing.ParamRequest;
 import com.clouway.oauth2.authorization.Authorization;
 import com.clouway.oauth2.authorization.ClientAuthorizationRepository;
 import com.clouway.oauth2.client.Client;
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 
+import static com.clouway.friendlyserve.testing.FakeRequest.aNewRequest;
 import static com.clouway.oauth2.client.ClientBuilder.aNewClient;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -50,9 +51,9 @@ public class ResourceOwnerClientAuthorizationTest {
 
   @Test
   public void happyPath() throws IOException {
-    ParamRequest authRequest = new ParamRequest(
+    Request authRequest = aNewRequest().params(
             ImmutableMap.of("response_type", "code", "client_id", "::client_id::", "redirect_uri", "http://example.com/callback")
-    );
+    ).build();
     final Client anyExistingClient = aNewClient().withRedirectUrl("http://example.com/callback").build();
 
     context.checking(new Expectations() {{
@@ -74,14 +75,14 @@ public class ResourceOwnerClientAuthorizationTest {
   @Test
   @SuppressWarnings("unchecked")
   public void stateIsPassedToCallbackWhenProvided() throws Exception {
-    ParamRequest authRequest = new ParamRequest(
+    Request authRequest = aNewRequest().params(
             ImmutableMap.of(
                     "response_type", "code",
                     "client_id", "::client_id::",
                     "redirect_uri", "http://example.com/callback",
                     "state", "abc"
             )
-    );
+    ).build();
     final Client anyExistingClient = aNewClient().withRedirectUrl("http://example.com/callback").build();
 
     context.checking(new Expectations() {{
@@ -101,14 +102,14 @@ public class ResourceOwnerClientAuthorizationTest {
 
   @Test
   public void singleScopeIsPassed() throws Exception {
-    ParamRequest authRequest = new ParamRequest(
+    Request authRequest = aNewRequest().params(
             ImmutableMap.of(
                     "response_type", "code",
                     "client_id", "::client_id::",
                     "redirect_uri", "http://example.com/callback",
                     "scope", "abc"
             )
-    );
+    ).build();
     final Client anyExistingClient = aNewClient().withRedirectUrl("http://example.com/callback").build();
 
     context.checking(new Expectations() {{
@@ -124,14 +125,14 @@ public class ResourceOwnerClientAuthorizationTest {
 
   @Test
   public void multipleScopesArePassed() throws Exception {
-    ParamRequest authRequest = new ParamRequest(
+    Request authRequest = aNewRequest().params(
             ImmutableMap.of(
                     "response_type", "code",
                     "client_id", "::client_id::",
                     "redirect_uri", "http://example.com/callback",
                     "scope", "CanDoX CanDoY CanDoZ"
             )
-    );
+    ).build();
     final Client anyExistingClient = aNewClient().withRedirectUrl("http://example.com/callback").build();
 
     context.checking(new Expectations() {{
@@ -147,9 +148,9 @@ public class ResourceOwnerClientAuthorizationTest {
 
   @Test
   public void redirectUrlWasNotRequested() throws Exception {
-    ParamRequest authRequest = new ParamRequest(
+    Request authRequest = aNewRequest().params(
             ImmutableMap.of("response_type", "code", "client_id", "::another client::")
-    );
+    ).build();
     final Client anyExistingClient = aNewClient().withRedirectUrl("http://example.com/callback").build();
 
     context.checking(new Expectations() {{
@@ -169,9 +170,9 @@ public class ResourceOwnerClientAuthorizationTest {
 
   @Test
   public void clientWasNotAuthorized() {
-    ParamRequest authRequest = new ParamRequest(
+    Request authRequest = aNewRequest().params(
             ImmutableMap.of("response_type", "code", "client_id", "::client_id::", "redirect_uri", "https://example.com/callback")
-    );
+    ).build();
     final Client anyExistingClient = aNewClient().withRedirectUrl("https://example.com/callback").build();
 
     context.checking(new Expectations() {{
@@ -192,9 +193,9 @@ public class ResourceOwnerClientAuthorizationTest {
 
   @Test
   public void unknownClient() {
-    ParamRequest authRequest = new ParamRequest(
+    Request authRequest = aNewRequest().params(
             ImmutableMap.of("response_type", "code", "client_id", "::client_id::", "redirect_uri", "https://example.com")
-    );
+    ).build();
     context.checking(new Expectations() {{
       oneOf(clientFinder).findClient("::client_id::");
       will(returnValue(Optional.absent()));
@@ -207,13 +208,13 @@ public class ResourceOwnerClientAuthorizationTest {
 
   @Test
   public void clientRedirectUrlIsNotMatching() throws Exception {
-    ParamRequest authRequest = new ParamRequest(
+    Request authRequest = aNewRequest().params(
             ImmutableMap.of(
                     "response_type", "code",
                     "client_id", "::client_id::",
                     "redirect_uri", "https://example.com"
             )
-    );
+    ).build();
 
     final Client anyExistingClient = aNewClient().withRedirectUrl("https://example.com/callback").build();
 

--- a/oauth2-server/src/test/java/com/clouway/oauth2/RetrieveUserInfoWithAccessTokenTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/RetrieveUserInfoWithAccessTokenTest.java
@@ -4,8 +4,8 @@ import com.clouway.friendlyserve.Request;
 import com.clouway.friendlyserve.Response;
 import com.clouway.friendlyserve.testing.ParamRequest;
 import com.clouway.friendlyserve.testing.RsPrint;
-import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.token.BearerToken;
+import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.token.Tokens;
 import com.clouway.oauth2.user.IdentityFinder;
 import com.google.common.base.Optional;
@@ -44,9 +44,9 @@ public class RetrieveUserInfoWithAccessTokenTest {
 
     context.checking(new Expectations() {{
       oneOf(tokens).findTokenAvailableAt("::any token id::", anyInstantTime);
-      will(returnValue(Optional.of(new BearerToken("", GrantType.AUTHORIZATION_CODE, "::identity_id::","", "::user email::", Collections.<String>emptySet(), anyInstantTime))));
+      will(returnValue(Optional.of(new BearerToken("", GrantType.AUTHORIZATION_CODE, "::identity_id::", "", "::user email::", Collections.<String>emptySet(), anyInstantTime, ImmutableMap.of("::index::", "::1::")))));
 
-      oneOf(identityFinder).findIdentity("::identity_id::", GrantType.AUTHORIZATION_CODE, anyInstantTime);
+      oneOf(identityFinder).findIdentity("::identity_id::", GrantType.AUTHORIZATION_CODE, anyInstantTime, ImmutableMap.of("::index::", "::1::"));
       will(returnValue(Optional.of(new Identity("985", "::user name::", "::user given name::", "::family name::", "::user email::", "::user picture::", Collections.<String, Object>emptyMap()))));
     }});
 
@@ -63,16 +63,16 @@ public class RetrieveUserInfoWithAccessTokenTest {
   public void identityWithPrivateClaims() throws Exception {
     final Tokens tokens = context.mock(Tokens.class);
     final Request request = new ParamRequest(
-            ImmutableMap.of("access_token", "::any token id::")
+            ImmutableMap.of("access_token", "::any token id::", "::otherparam::", "::1::")
     );
     final IdentityFinder identityFinder = context.mock(IdentityFinder.class);
     final DateTime anyInstantTime = new DateTime();
 
     context.checking(new Expectations() {{
       oneOf(tokens).findTokenAvailableAt(with(any(String.class)), with(any(DateTime.class)));
-      will(returnValue(Optional.of(new BearerToken("", GrantType.AUTHORIZATION_CODE, "::identity_id::", "", "::user email::", Collections.<String>emptySet(), anyInstantTime))));
+      will(returnValue(Optional.of(new BearerToken("", GrantType.AUTHORIZATION_CODE, "::identity_id::", "", "::user email::", Collections.<String>emptySet(), anyInstantTime, ImmutableMap.of("::index::", "::1::")))));
 
-      oneOf(identityFinder).findIdentity("::identity_id::", GrantType.AUTHORIZATION_CODE, anyInstantTime);
+      oneOf(identityFinder).findIdentity("::identity_id::", GrantType.AUTHORIZATION_CODE, anyInstantTime, ImmutableMap.of("::index::", "::1::"));
       will(returnValue(Optional.of(new Identity("985", "::user name::", "::user given name::", "::family name::", "::user email::", "::user picture::",
               ImmutableMap.<String, Object>of("claim1", "::any string value::", "claim2", 342)))));
     }});
@@ -111,9 +111,9 @@ public class RetrieveUserInfoWithAccessTokenTest {
 
     context.checking(new Expectations() {{
       oneOf(tokens).findTokenAvailableAt("::any token id::", anyInstantTime);
-      will(returnValue(Optional.of(new BearerToken("", GrantType.JWT, "::identity_id::", "", "::user email::", Collections.<String>emptySet(), anyInstantTime))));
+      will(returnValue(Optional.of(new BearerToken("", GrantType.JWT, "::identity_id::", "", "::user email::", Collections.<String>emptySet(), anyInstantTime, ImmutableMap.of("::index::", "::1::")))));
 
-      oneOf(identityFinder).findIdentity("::identity_id::", GrantType.JWT, anyInstantTime);
+      oneOf(identityFinder).findIdentity("::identity_id::", GrantType.JWT, anyInstantTime, ImmutableMap.of("::index::", "::1::"));
       will(returnValue(Optional.absent()));
     }});
 

--- a/oauth2-server/src/test/java/com/clouway/oauth2/token/TokenEqualityTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/token/TokenEqualityTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.Date;
 
+import static com.google.common.collect.ImmutableMap.of;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
@@ -18,8 +19,8 @@ public class TokenEqualityTest {
   @Test
   public void areEqual() {
     DateTime creationDate = new DateTime();
-    BearerToken token1 = new BearerToken("value", GrantType.AUTHORIZATION_CODE, "identityId", "::client id::", "::email::", Collections.<String>emptySet(), creationDate);
-    BearerToken token2 = new BearerToken("value", GrantType.AUTHORIZATION_CODE, "identityId", "::client id::", "::email::", Collections.<String>emptySet(), creationDate);
+    BearerToken token1 = new BearerToken("value", GrantType.AUTHORIZATION_CODE, "identityId", "::client id::", "::email::", Collections.<String>emptySet(), creationDate, of("::index::", "::1::"));
+    BearerToken token2 = new BearerToken("value", GrantType.AUTHORIZATION_CODE, "identityId", "::client id::", "::email::", Collections.<String>emptySet(), creationDate, of("::index::", "::1::"));
 
     assertThat(token1, is(token2));
   }
@@ -27,16 +28,16 @@ public class TokenEqualityTest {
   @Test
   public void areNotEqual() {
     DateTime creationDate = new DateTime();
-    BearerToken token1 = new BearerToken("value1", GrantType.AUTHORIZATION_CODE, "identityId", "::client id::", "::email::", Collections.<String>emptySet(), creationDate);
-    BearerToken token2 = new BearerToken("value2", GrantType.AUTHORIZATION_CODE, "identityId", "::client id::", "::email::", Collections.<String>emptySet(), creationDate);
+    BearerToken token1 = new BearerToken("value1", GrantType.AUTHORIZATION_CODE, "identityId", "::client id::", "::email::", Collections.<String>emptySet(), creationDate, of("::index::", "::1::"));
+    BearerToken token2 = new BearerToken("value2", GrantType.AUTHORIZATION_CODE, "identityId", "::client id::", "::email::", Collections.<String>emptySet(), creationDate, of("::index::", "::1::"));
 
     assertThat(token1, is(not(token2)));
   }
 
   @Test
   public void areNotEqualWhenDifferentExpirationTimes() {
-    BearerToken token1 = new BearerToken("value", GrantType.AUTHORIZATION_CODE, "identityId", "::client id::", "::email::", Collections.<String>emptySet(), new DateTime(new Date(1408532291030L)));
-    BearerToken token2 = new BearerToken("value", GrantType.AUTHORIZATION_CODE, "identityId", "::client id::", "::email::", Collections.<String>emptySet(), new DateTime(new Date(1408532291031L)));
+    BearerToken token1 = new BearerToken("value", GrantType.AUTHORIZATION_CODE, "identityId", "::client id::", "::email::", Collections.<String>emptySet(), new DateTime(new Date(1408532291030L)), of("::index::", "::1::"));
+    BearerToken token2 = new BearerToken("value", GrantType.AUTHORIZATION_CODE, "identityId", "::client id::", "::email::", Collections.<String>emptySet(), new DateTime(new Date(1408532291031L)), of("::index::", "::1::"));
 
     assertThat(token1, is(not(token2)));
   }

--- a/oauth2-server/src/test/java/com/clouway/oauth2/util/ParamsTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/util/ParamsTest.java
@@ -1,0 +1,30 @@
+package com.clouway.oauth2.util;
+
+import com.clouway.friendlyserve.Request;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static com.clouway.friendlyserve.testing.FakeRequest.aNewRequest;
+import static com.google.common.collect.ImmutableMap.of;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Mihail Lesikov (mlesikov@gmail.com)
+ */
+public class ParamsTest {
+  @Test
+  public void parse() throws Exception {
+    Map<String, String> params = new Params().parse(aNewRequest().param("::index::", "::1::").build());
+    assertThat(params, CoreMatchers.<Map<String, String>>is(of("::index::", "::1::")));
+  }
+
+  @Test
+  public void excludeParams() throws Exception {
+    Request request = aNewRequest().param("::i::", "::1::").param("::codeparam::", "::1::").param("::otherparam::", "::1::").build();
+    Map<String, String> params = new Params().parse(request, "::codeparam::", "::otherparam::");
+    assertThat(params, CoreMatchers.<Map<String, String>>is(of("::i::", "::1::")));
+  }
+
+}


### PR DESCRIPTION
Handle index param of the request and pass it to the identityFinder.
This index can be used for selecting accounts of specific namespace