### PR TITLE
oauth2-server: remote un-used verify method

### DIFF
--- a/oauth2-server/src/main/java/com/clouway/oauth2/jws/RsaJwsSignature.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/jws/RsaJwsSignature.java
@@ -1,16 +1,10 @@
 package com.clouway.oauth2.jws;
 
-import com.clouway.oauth2.jws.Pem.Block;
-
 import java.security.KeyFactory;
 import java.security.PrivateKey;
-import java.security.PublicKey;
 import java.security.Signature;
 import java.security.spec.PKCS8EncodedKeySpec;
-import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
-
-import static com.google.common.io.BaseEncoding.base64;
 
 /**
  * RsaJwsSignature is an implementation of {@link com.clouway.oauth2.jws.Signature} that uses
@@ -48,21 +42,4 @@ public class RsaJwsSignature implements com.clouway.oauth2.jws.Signature {
     }
   }
 
-  @Override
-  public boolean verify(byte[] content, Block key) {
-    try {
-      X509EncodedKeySpec keySpec = new X509EncodedKeySpec(key.getBytes());
-      KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-      PublicKey publicKey = keyFactory.generatePublic(keySpec);
-      Signature sig = Signature.getInstance("SHA256withRSA");
-
-      sig.initVerify(publicKey);
-      sig.update(content);
-
-      return sig.verify(signature);
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-    return false;
-  }
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/jws/Signature.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/jws/Signature.java
@@ -23,14 +23,4 @@ public interface Signature {
    */
   boolean verifyWithPrivateKey(byte[] content, Pem.Block privateKey);
 
-  /**
-   * Verify is veryfying Signature using the provided publicKey as PEM file
-   * <p/>
-   *
-   * @param content to be verified
-   * @param key The public key to verify the content with
-   * @return
-   */
-  boolean verify(byte[] content, Block key);
-
 }


### PR DESCRIPTION
The un-used method verify is now removed from the Signature interface.