### PR TITLE
oauth2/api: pass object instead of list of params

### DIFF
--- a/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryTokens.java
+++ b/oauth2-example-app/src/main/java/com/clouway/oauth2/exampleapp/storage/InMemoryTokens.java
@@ -7,6 +7,7 @@ import com.clouway.oauth2.client.Client;
 import com.clouway.oauth2.token.BearerToken;
 import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.token.TokenGenerator;
+import com.clouway.oauth2.token.TokenRequest;
 import com.clouway.oauth2.token.TokenResponse;
 import com.clouway.oauth2.token.Tokens;
 import com.google.common.base.Optional;
@@ -72,11 +73,11 @@ class InMemoryTokens implements Tokens {
   }
 
   @Override
-  public TokenResponse issueToken(GrantType grantType, Client client, Identity identity, Set<String> scopes, DateTime when, Map<String, String> params) {
+  public TokenResponse issueToken(TokenRequest tokenRequest) {
     String token = tokenGenerator.generate();
     String refreshTokenValue = tokenGenerator.generate();
 
-    BearerToken bearerToken = new BearerToken(token, GrantType.JWT, identity.id(), client.id, identity.email(), scopes, when, params);
+    BearerToken bearerToken = new BearerToken(token, GrantType.JWT, tokenRequest.identity.id(), tokenRequest.client.id, tokenRequest.identity.email(), tokenRequest.scopes, tokenRequest.when, tokenRequest.params);
     tokens.put(token, bearerToken);
 
     return new TokenResponse(true, bearerToken, refreshTokenValue);

--- a/oauth2-server/src/main/java/com/clouway/oauth2/IssueNewTokenActivity.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/IssueNewTokenActivity.java
@@ -13,6 +13,8 @@ import com.google.common.base.Optional;
 import java.util.Map;
 import java.util.Set;
 
+import static com.clouway.oauth2.token.TokenRequest.newTokenRequest;
+
 
 /**
  * IssueNewTokenActivity is representing the activity which is performed for issuing of new token.
@@ -30,7 +32,16 @@ class IssueNewTokenActivity implements AuthorizedIdentityActivity {
 
   @Override
   public Response execute(Client client, Identity identity, Set<String> scopes, Request request, DateTime instant, Map<String, String> params) {
-    TokenResponse response = tokens.issueToken(GrantType.AUTHORIZATION_CODE, client, identity, scopes, instant, params);
+    TokenResponse response = tokens.issueToken(
+            newTokenRequest()
+                    .grantType(GrantType.AUTHORIZATION_CODE)
+                    .client(client)
+                    .identity(identity)
+                    .scopes(scopes)
+                    .when(instant)
+                    .params(params)
+                    .build());
+
     if (!response.isSuccessful()) {
       return OAuthError.invalidRequest("Token cannot be issued.");
     }
@@ -47,7 +58,7 @@ class IssueNewTokenActivity implements AuthorizedIdentityActivity {
     if (possibleIdToken.isPresent()) {
       return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), accessToken.scopes, response.refreshToken, possibleIdToken.get());
     }
-    
+
     return new BearerTokenResponse(accessToken.value, accessToken.ttlSeconds(instant), accessToken.scopes, response.refreshToken);
   }
 }

--- a/oauth2-server/src/main/java/com/clouway/oauth2/jwt/JwtController.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/jwt/JwtController.java
@@ -3,8 +3,6 @@ package com.clouway.oauth2.jwt;
 import com.clouway.friendlyserve.Request;
 import com.clouway.friendlyserve.Response;
 import com.clouway.oauth2.BearerTokenResponse;
-import com.clouway.oauth2.token.IdTokenFactory;
-import com.clouway.oauth2.util.Params;
 import com.clouway.oauth2.DateTime;
 import com.clouway.oauth2.Identity;
 import com.clouway.oauth2.InstantaneousRequest;
@@ -16,9 +14,11 @@ import com.clouway.oauth2.jws.Signature;
 import com.clouway.oauth2.jws.SignatureFactory;
 import com.clouway.oauth2.token.BearerToken;
 import com.clouway.oauth2.token.GrantType;
+import com.clouway.oauth2.token.IdTokenFactory;
 import com.clouway.oauth2.token.TokenResponse;
 import com.clouway.oauth2.token.Tokens;
 import com.clouway.oauth2.user.IdentityFinder;
+import com.clouway.oauth2.util.Params;
 import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
@@ -30,6 +30,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static com.clouway.oauth2.token.TokenRequest.newTokenRequest;
 
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)
@@ -105,7 +107,16 @@ public class JwtController implements InstantaneousRequest {
 
     Set<String> scopes = Sets.newTreeSet(Splitter.on(" ").omitEmptyStrings().split(scope));
     Client client = new Client(claimSet.iss, "", "", Collections.<String>emptySet(), false);
-    TokenResponse response = tokens.issueToken(GrantType.JWT, client, identity, scopes, instant, params);
+
+    TokenResponse response = tokens.issueToken(
+            newTokenRequest()
+                    .grantType(GrantType.JWT)
+                    .client(client)
+                    .identity(identity)
+                    .scopes(scopes)
+                    .when(instant)
+                    .params(params)
+                    .build());
 
     if (!response.isSuccessful()) {
       return OAuthError.invalidRequest("tokens issuing is temporary unavailable");

--- a/oauth2-server/src/main/java/com/clouway/oauth2/token/TokenRequest.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/token/TokenRequest.java
@@ -1,44 +1,100 @@
 package com.clouway.oauth2.token;
 
+import com.clouway.oauth2.DateTime;
+import com.clouway.oauth2.Identity;
+import com.clouway.oauth2.client.Client;
+import com.google.common.base.Objects;
+
+import java.util.Map;
+import java.util.Set;
+
 /**
  * @author Ivan Stefanov <ivan.stefanov@clouway.com>
  */
-public class TokenRequest {
-  public final String grantType;
-  public final String code;
-  public final String refreshToken;
-  public final String clientId;
-  public final String clientSecret;
+public final class TokenRequest {
 
-  public TokenRequest(String grantType, String code, String refreshToken, String clientId, String clientSecret) {
-    this.grantType = grantType;
-    this.code = code;
-    this.refreshToken = refreshToken;
-    this.clientId = clientId;
-    this.clientSecret = clientSecret;
+  public static final class Builder {
+    private GrantType grantType;
+    private Client client;
+    private Identity identity;
+    private Set<String> scopes;
+    private DateTime when;
+    private Map<String, String> params;
+
+    private Builder() {
+    }
+
+    public TokenRequest build() {
+      return new TokenRequest(this);
+    }
+
+    public Builder grantType(GrantType grantType) {
+      this.grantType = grantType;
+      return this;
+    }
+
+    public Builder client(Client client) {
+      this.client = client;
+      return this;
+    }
+
+    public Builder identity(Identity identity) {
+      this.identity = identity;
+      return this;
+    }
+
+    public Builder scopes(Set<String> scopes) {
+      this.scopes = scopes;
+      return this;
+    }
+
+    public Builder when(DateTime when) {
+      this.when = when;
+      return this;
+    }
+
+    public Builder params(Map<String, String> params) {
+      this.params = params;
+      return this;
+    }
+  }
+
+  public final GrantType grantType;
+  public final Client client;
+  public final Identity identity;
+  public final Set<String> scopes;
+  public final DateTime when;
+  public final Map<String, String> params;
+
+  private TokenRequest(Builder builder) {
+    this.grantType = builder.grantType;
+    this.client = builder.client;
+    this.identity = builder.identity;
+    this.scopes = builder.scopes;
+    this.when = builder.when;
+    this.params = builder.params;
+  }
+
+  public static Builder newTokenRequest() {
+    return new Builder();
   }
 
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-
     TokenRequest that = (TokenRequest) o;
-
-    if (clientId != null ? !clientId.equals(that.clientId) : that.clientId != null) return false;
-    if (clientSecret != null ? !clientSecret.equals(that.clientSecret) : that.clientSecret != null) return false;
-    if (code != null ? !code.equals(that.code) : that.code != null) return false;
-    if (grantType != null ? !grantType.equals(that.grantType) : that.grantType != null) return false;
-
-    return true;
+    return grantType == that.grantType &&
+            Objects.equal(client, that.client) &&
+            Objects.equal(identity, that.identity) &&
+            Objects.equal(scopes, that.scopes) &&
+            Objects.equal(when, that.when) &&
+            Objects.equal(params, that.params);
   }
 
   @Override
   public int hashCode() {
-    int result = grantType != null ? grantType.hashCode() : 0;
-    result = 31 * result + (code != null ? code.hashCode() : 0);
-    result = 31 * result + (clientId != null ? clientId.hashCode() : 0);
-    result = 31 * result + (clientSecret != null ? clientSecret.hashCode() : 0);
-    return result;
+    return Objects.hashCode(grantType, client, identity, scopes, when, params);
   }
 }
+

--- a/oauth2-server/src/main/java/com/clouway/oauth2/token/Tokens.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/token/Tokens.java
@@ -35,15 +35,16 @@ public interface Tokens {
   /**
    * Issues a new token for the provided identity.
    *
-   * @param grantType  type of the taken to be issued - JWT or Bearer
-   * @param client     the client to which token will be issued
-   * @param identity   the identity for which token was issued
-   * @param scopes     requested scopes
-   * @param when       the requested time on which it should be issued
-   * @param params
+   * @param tokenRequest:
+   *  grantType  type of the taken to be issued - JWT or Bearer
+   *  client     the client to which token will be issued
+   *  identity   the identity for which token was issued
+   *  scopes     requested scopes
+   *  when       the requested time on which it should be issued
+   *  params
    * @return the newly issued token
    */
-  TokenResponse issueToken(GrantType grantType, Client client, Identity identity, Set<String> scopes, DateTime when, Map<String, String> params);
+  TokenResponse issueToken(TokenRequest tokenRequest);
 
   /**
    * Revokes token from repository.

--- a/oauth2-server/src/test/java/com/clouway/oauth2/IssueNewTokenForClientTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/IssueNewTokenForClientTest.java
@@ -8,6 +8,7 @@ import com.clouway.oauth2.authorization.Authorization;
 import com.clouway.oauth2.client.Client;
 import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.token.IdTokenFactory;
+import com.clouway.oauth2.token.TokenRequest;
 import com.clouway.oauth2.token.TokenResponse;
 import com.clouway.oauth2.token.Tokens;
 import com.google.common.base.Optional;
@@ -26,6 +27,7 @@ import static com.clouway.oauth2.BearerTokenBuilder.aNewToken;
 import static com.clouway.oauth2.IdentityBuilder.aNewIdentity;
 import static com.clouway.oauth2.authorization.AuthorizationBuilder.newAuthorization;
 import static com.clouway.oauth2.client.ClientBuilder.aNewClient;
+import static com.clouway.oauth2.token.TokenRequest.newTokenRequest;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -63,7 +65,7 @@ public class IssueNewTokenForClientTest {
               with(any(Long.class)), with(any(DateTime.class)));
       will(returnValue(Optional.of("::base64.encoded.idToken::")));
 
-      oneOf(tokens).issueToken(with(any(GrantType.class)), with(any(Client.class)), with(any(Identity.class)), with(any(Set.class)), with(any(DateTime.class)), with(ImmutableMap.of("::index::", "::1::")));
+      oneOf(tokens).issueToken(with(any(TokenRequest.class)));
       will(returnValue(new TokenResponse(true, aNewToken().withValue("::token::").build(), "::refresh token::")));
     }});
 
@@ -90,7 +92,7 @@ public class IssueNewTokenForClientTest {
               with(any(Long.class)), with(any(DateTime.class)));
       will(returnValue(Optional.absent()));
 
-      oneOf(tokens).issueToken(with(any(GrantType.class)), with(any(Client.class)), with(any(Identity.class)), with(any(Set.class)), with(any(DateTime.class)), with(ImmutableMap.of("::index::", "::1::")));
+      oneOf(tokens).issueToken(with(any(TokenRequest.class)));
       will(returnValue(new TokenResponse(true, aNewToken().withValue("::token::").build(), "::refresh token::")));
     }});
 
@@ -109,7 +111,7 @@ public class IssueNewTokenForClientTest {
     final Identity identity = aNewIdentity().withId("::user_id::").build();
 
     context.checking(new Expectations() {{
-      oneOf(tokens).issueToken(with(any(GrantType.class)), with(any(Client.class)), with(any(Identity.class)), with(any(Set.class)), with(any(DateTime.class)), with(ImmutableMap.of("::index::", "::1::")));
+      oneOf(tokens).issueToken(with(any(TokenRequest.class)));
       will(returnValue(new TokenResponse(false, null, "")));
     }});
 
@@ -128,7 +130,15 @@ public class IssueNewTokenForClientTest {
     final Authorization authorization = newAuthorization().build();
 
     context.checking(new Expectations() {{
-      oneOf(tokens).issueToken(GrantType.AUTHORIZATION_CODE, client, identity, authorization.scopes, anyTime, ImmutableMap.of("::index::", "::1::"));
+      oneOf(tokens).issueToken(
+              newTokenRequest()
+                      .grantType(GrantType.AUTHORIZATION_CODE)
+                      .client(client)
+                      .identity(identity)
+                      .scopes(authorization.scopes)
+                      .when(anyTime)
+                      .params(ImmutableMap.of("::index::", "::1::"))
+                      .build());
       will(returnValue(new TokenResponse(false, null, "")));
     }});
 

--- a/oauth2-server/src/test/java/com/clouway/oauth2/jwt/HandleJwtTokenRequestsTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/jwt/HandleJwtTokenRequestsTest.java
@@ -12,6 +12,7 @@ import com.clouway.oauth2.jws.Signature;
 import com.clouway.oauth2.jws.SignatureFactory;
 import com.clouway.oauth2.token.GrantType;
 import com.clouway.oauth2.token.IdTokenFactory;
+import com.clouway.oauth2.token.TokenRequest;
 import com.clouway.oauth2.token.TokenResponse;
 import com.clouway.oauth2.token.Tokens;
 import com.clouway.oauth2.user.IdentityFinder;
@@ -33,6 +34,7 @@ import java.util.Set;
 import static com.clouway.friendlyserve.testing.FakeRequest.aNewRequest;
 import static com.clouway.oauth2.BearerTokenBuilder.aNewToken;
 import static com.clouway.oauth2.IdentityBuilder.aNewIdentity;
+import static com.clouway.oauth2.token.TokenRequest.newTokenRequest;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -92,7 +94,7 @@ public class HandleJwtTokenRequestsTest {
       oneOf(idTokenFactory).create(with(any(String.class)),with(any(String.class)),with(any(Identity.class)),with(any(Long.class)),with(any(DateTime.class)));
       will(returnValue(Optional.of("::id_token::")));
 
-      oneOf(tokens).issueToken(with(any(GrantType.class)), with(any(Client.class)), with(any(Identity.class)), with(any(Set.class)), with(any(DateTime.class)), with(Maps.<String, String>newHashMap()));
+      oneOf(tokens).issueToken(with(any(TokenRequest.class)));
       will(returnValue(new TokenResponse(true, aNewToken().withValue("::access_token::").expiresAt(anyInstantTime.plusSeconds(1000)).build(), "::refresh_token::")));
     }});
 
@@ -125,7 +127,7 @@ public class HandleJwtTokenRequestsTest {
       oneOf(idTokenFactory).create(with(any(String.class)),with(any(String.class)),with(any(Identity.class)),with(any(Long.class)),with(any(DateTime.class)));
       will(returnValue(Optional.absent()));
 
-      oneOf(tokens).issueToken(with(any(GrantType.class)), with(any(Client.class)), with(any(Identity.class)), with(any(Set.class)), with(any(DateTime.class)), with(Maps.<String, String>newHashMap()));
+      oneOf(tokens).issueToken(with(any(TokenRequest.class)));
       will(returnValue(new TokenResponse(true, aNewToken().withValue("::access_token::").expiresAt(anyInstantTime.plusSeconds(1000)).build(), "::refresh_token::")));
     }});
 
@@ -184,7 +186,14 @@ public class HandleJwtTokenRequestsTest {
       will(returnValue(Optional.of(identity)));
 
       oneOf(tokens).issueToken(
-              GrantType.JWT, jwtClient, identity, Sets.newHashSet("CanDoX", "CanDoY"), anyInstantTime, Maps.<String, String>newHashMap());
+              newTokenRequest()
+                      .grantType(GrantType.JWT)
+                      .client(jwtClient)
+                      .identity(identity)
+                      .scopes(Sets.newHashSet("CanDoX", "CanDoY"))
+                      .when(anyInstantTime)
+                      .params(Maps.<String, String>newHashMap())
+                      .build());
       will(returnValue(new TokenResponse(true, aNewToken().build(), "")));
 
       oneOf(idTokenFactory).create(with(any(String.class)),with(any(String.class)),with(any(Identity.class)),with(any(Long.class)),with(any(DateTime.class)));
@@ -216,7 +225,14 @@ public class HandleJwtTokenRequestsTest {
       will(returnValue(Optional.of(identity)));
 
       oneOf(tokens).issueToken(
-              GrantType.JWT, jwtClient, identity, Sets.newHashSet("CanDoX", "CanDoY"), anyInstantTime, ImmutableMap.of("::index::", "::1::"));
+              newTokenRequest()
+                      .grantType(GrantType.JWT)
+                      .client(jwtClient)
+                      .identity(identity)
+                      .scopes(Sets.newHashSet("CanDoX", "CanDoY"))
+                      .when(anyInstantTime)
+                      .params(ImmutableMap.of("::index::", "::1::"))
+                      .build());
       will(returnValue(new TokenResponse(true, aNewToken().build(), "")));
 
       oneOf(idTokenFactory).create(with(any(String.class)),with(any(String.class)),with(any(Identity.class)),with(any(Long.class)),with(any(DateTime.class)));

--- a/oauth2-server/src/test/java/com/clouway/oauth2/token/TokenRequestEqualityTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/token/TokenRequestEqualityTest.java
@@ -1,10 +1,7 @@
 package com.clouway.oauth2.token;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
-
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author Ivan Stefanov <ivan.stefanov@clouway.com>
@@ -12,17 +9,6 @@ import static org.junit.Assert.assertThat;
 public class TokenRequestEqualityTest {
   @Test
   public void areEqual() {
-    TokenRequest request1 = new TokenRequest("grant_type", "code","refresh_token", "client_id", "client_secret");
-    TokenRequest request2 = new TokenRequest("grant_type", "code","refresh_token", "client_id", "client_secret");
-
-    assertThat(request1, is(request2));
-  }
-
-  @Test
-  public void areNotEqual() {
-    TokenRequest request1 = new TokenRequest("grant_type1", "code1","refresh_token", "client_id1", "client_secret1");
-    TokenRequest request2 = new TokenRequest("grant_type2", "code2","refresh_token", "client_id2", "client_secret2");
-
-    assertThat(request1, is(not(request2)));
+    EqualsVerifier.forClass(TokenRequest.class).verify();
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,15 @@
     </dependencies>
   </dependencyManagement>
 
+  <dependencies>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <version>2.4</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <build>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
In Tokens now an object TokenRequest is passed instead of parameters for better readability. 
A builder has been also added.

I'm not sure i should keep these long tests for equality for TokenRequest.

Fixes: #73