### PR TITLE
oauth2-server: code in authorization reseponse is url encoded

### DIFF
--- a/oauth2-server/src/main/java/com/clouway/oauth2/authorization/AuthorizationResponse.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/authorization/AuthorizationResponse.java
@@ -1,5 +1,8 @@
 package com.clouway.oauth2.authorization;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
 /**
  * @author Ivan Stefanov <ivan.stefanov@clouway.com>
  */
@@ -13,6 +16,10 @@ public class AuthorizationResponse {
   }
 
   public String buildURI() {
-    return redirectURI + "?code=" + code;
+    try {
+      return redirectURI + "?code=" + URLEncoder.encode(code, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      return  redirectURI + "?code=" + code;
+    }
   }
 }

--- a/oauth2-server/src/test/java/com/clouway/oauth2/AuthorizationResponseTest.java
+++ b/oauth2-server/src/test/java/com/clouway/oauth2/AuthorizationResponseTest.java
@@ -23,4 +23,14 @@ public class AuthorizationResponseTest {
 
     assertThat(response.buildURI(), is("http://zazz.bg/?code=987654321"));
   }
+
+  @Test
+  public void codeIsUrlSafelyEncoded() throws Exception {
+    AuthorizationResponse response = new AuthorizationResponse(
+            "a test 23",
+            "http://zazz.bg/"
+    );
+
+    assertThat(response.buildURI(), is("http://zazz.bg/?code=a+test+23"));
+  }
 }


### PR DESCRIPTION
The code in the authorization response url is now url encoded and allows not url safe strings to be returned as code.

Thanks to Ivan Surzhenko for the feedback.