### PR TITLE
oauth2/integration: better library integration

### DIFF
--- a/oauth2-server/src/main/java/com/clouway/oauth2/OAuth2ApiSupport.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/OAuth2ApiSupport.java
@@ -1,0 +1,14 @@
+package com.clouway.oauth2;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * @author Mihail Lesikov (mihail.lesikov@clouway.com)
+ */
+public interface OAuth2ApiSupport {
+
+  void serve(HttpServletRequest req, HttpServletResponse resp) throws IOException;
+
+}

--- a/oauth2-server/src/main/java/com/clouway/oauth2/OAuth2ApiSupportFactory.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/OAuth2ApiSupportFactory.java
@@ -1,0 +1,131 @@
+package com.clouway.oauth2;
+
+import com.clouway.friendlyserve.FkRegex;
+import com.clouway.friendlyserve.RequestHandlerMatchingParam;
+import com.clouway.friendlyserve.RequiresParam;
+import com.clouway.friendlyserve.TkFork;
+import com.clouway.friendlyserve.servlets.ServletApiSupport;
+import com.clouway.oauth2.codechallenge.AuthorizationCodeVerifier;
+import com.clouway.oauth2.jws.RsaJwsSignature;
+import com.clouway.oauth2.jws.Signature;
+import com.clouway.oauth2.jws.SignatureFactory;
+import com.clouway.oauth2.jwt.Jwt.Header;
+import com.clouway.oauth2.jwt.JwtController;
+import com.clouway.oauth2.token.JjwtIdTokenFactory;
+import com.google.common.base.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * @author Mihail Lesikov (mihail.lesikov@clouway.com)
+ */
+public class OAuth2ApiSupportFactory {
+
+  public OAuth2ApiSupport create(OAuth2Config config) {
+    final SignatureFactory signatureFactory = new SignatureFactory() {
+      @Override
+      public Optional<Signature> createSignature(byte[] signatureValue, Header header) {
+        // It's vulnerable multiple algorithms to be supported, so server need to reject
+        // any calls from not supported algorithms
+        // More infromation could be taken from: https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/
+        if (!"RS256".equals(header.alg)) {
+          return Optional.absent();
+        }
+        return Optional.<Signature>of(new RsaJwsSignature(signatureValue));
+      }
+    };
+
+
+    JjwtIdTokenFactory idTokenFactory = new JjwtIdTokenFactory(config.keyStore());
+    TkFork fork = new TkFork(
+            new FkRegex(".*/auth",
+                    new InstantaneousRequestController(
+                            new IdentityController(
+                                    config.resourceOwnerIdentityFinder(),
+                                    new ClientAuthorizationActivity(config.clientFinder(), config.clientAuthorizationRepository()), config.loginPageUrl())
+                    )
+            ),
+            new FkRegex(".*/token",
+                    new TkFork(
+                            new RequestHandlerMatchingParam("grant_type", "authorization_code",
+                                    new InstantaneousRequestController(
+                                            new ClientAuthenticationCredentialsRequest(
+                                                    new ClientController(
+                                                            config.clientFinder(),
+                                                            new AuthCodeAuthorization(
+                                                                    config.clientAuthorizationRepository(),
+                                                                    new CodeExchangeVerificationFlow(
+                                                                            new AuthorizationCodeVerifier(),
+                                                                            new IdentityAuthorizationActivity(
+                                                                                    config.identityFinder(),
+                                                                                    new IssueNewTokenActivity(
+                                                                                            config.tokens(),
+                                                                                            idTokenFactory)
+                                                                            )
+                                                                    )
+                                                            )
+
+                                                    )
+                                            ))
+                            ),
+                            new RequestHandlerMatchingParam("grant_type", "refresh_token",
+                                    new InstantaneousRequestController(
+                                            new ClientAuthenticationCredentialsRequest(
+                                                    new ClientController(
+                                                            config.clientFinder(),
+                                                            new RefreshTokenActivity(config.tokens(), idTokenFactory, config.identityFinder())
+                                                    ))
+
+                                    )
+                            ),
+                            // JWT Support
+                            new RequestHandlerMatchingParam("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer", new RequiresParam("assertion",
+                                    new InstantaneousRequestController(
+                                            new JwtController(
+                                                    signatureFactory,
+                                                    config.tokens(),
+                                                    config.jwtKeyStore(),
+                                                    config.identityFinder(),
+                                                    idTokenFactory
+                                            )))
+                            ))
+            ),
+            new FkRegex(".*/revoke",
+                    new RequiresParam("token",
+                            new InstantaneousRequestController(
+                                    new ClientAuthenticationCredentialsRequest(
+                                            new RevokeTokenController(config.clientFinder(), config.tokens())
+                                    )
+                            )
+                    )
+            ),
+            new FkRegex(".*/tokenInfo",
+                    new RequiresParam("access_token",
+                            new InstantaneousRequestController(
+                                    new TokenInfoController(config.tokens(), config.identityFinder(), idTokenFactory)
+                            )
+                    )
+            ),
+            new FkRegex(".*/userInfo",
+                    new RequiresParam("access_token",
+                            new InstantaneousRequestController(
+                                    new UserInfoController(config.identityFinder(), config.tokens())
+                            ))
+            ),
+            new FkRegex(".*/certs", new PublicCertsController(config.keyStore()))
+    );
+
+
+    final ServletApiSupport servletApiSupport = new ServletApiSupport(fork);
+
+
+    return new OAuth2ApiSupport() {
+      @Override
+      public void serve(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        servletApiSupport.serve(req, resp);
+      }
+    };
+  }
+}

--- a/oauth2-server/src/main/java/com/clouway/oauth2/OAuth2Servlet.java
+++ b/oauth2-server/src/main/java/com/clouway/oauth2/OAuth2Servlet.java
@@ -1,19 +1,5 @@
 package com.clouway.oauth2;
 
-import com.clouway.friendlyserve.FkRegex;
-import com.clouway.friendlyserve.RequestHandlerMatchingParam;
-import com.clouway.friendlyserve.RequiresParam;
-import com.clouway.friendlyserve.TkFork;
-import com.clouway.friendlyserve.servlets.ServletApiSupport;
-import com.clouway.oauth2.codechallenge.AuthorizationCodeVerifier;
-import com.clouway.oauth2.jws.RsaJwsSignature;
-import com.clouway.oauth2.jws.Signature;
-import com.clouway.oauth2.jws.SignatureFactory;
-import com.clouway.oauth2.jwt.Jwt.Header;
-import com.clouway.oauth2.jwt.JwtController;
-import com.clouway.oauth2.token.JjwtIdTokenFactory;
-import com.google.common.base.Optional;
-
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -25,112 +11,18 @@ import java.io.IOException;
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
 public abstract class OAuth2Servlet extends HttpServlet {
-  private ServletApiSupport servletApiSupport;
+  private OAuth2ApiSupport apiSupport;
 
   @Override
   public void init(ServletConfig servletConfig) throws ServletException {
     super.init(servletConfig);
-
-    final SignatureFactory signatureFactory = new SignatureFactory() {
-      @Override
-      public Optional<Signature> createSignature(byte[] signatureValue, Header header) {
-        // It's vulnerable multiple algorithms to be supported, so server need to reject
-        // any calls from not supported algorithms
-        // More infromation could be taken from: https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/
-        if (!"RS256".equals(header.alg)) {
-          return Optional.absent();
-        }
-        return Optional.<Signature>of(new RsaJwsSignature(signatureValue));
-      }
-    };
-
-    OAuth2Config config = config();
-
-    JjwtIdTokenFactory idTokenFactory = new JjwtIdTokenFactory(config.keyStore());
-    TkFork fork = new TkFork(
-            new FkRegex(".*/auth",
-                    new InstantaneousRequestController(
-                            new IdentityController(
-                                    config.resourceOwnerIdentityFinder(),
-                                    new ClientAuthorizationActivity(config.clientFinder(), config.clientAuthorizationRepository()), config.loginPageUrl())
-                    )
-            ),
-            new FkRegex(".*/token",
-                    new TkFork(
-                            new RequestHandlerMatchingParam("grant_type", "authorization_code",
-                                    new InstantaneousRequestController(
-                                            new ClientAuthenticationCredentialsRequest(
-                                                    new ClientController(
-                                                            config.clientFinder(),
-                                                            new AuthCodeAuthorization(
-                                                                    config.clientAuthorizationRepository(),
-                                                                    new CodeExchangeVerificationFlow(
-                                                                            new AuthorizationCodeVerifier(),
-                                                                            new IdentityAuthorizationActivity(
-                                                                                    config.identityFinder(),
-                                                                                    new IssueNewTokenActivity(
-                                                                                            config.tokens(),
-                                                                                            idTokenFactory)
-                                                                            )
-                                                                    )
-                                                            )
-
-                                                    )
-                                            ))
-                            ),
-                            new RequestHandlerMatchingParam("grant_type", "refresh_token",
-                                    new InstantaneousRequestController(
-                                            new ClientAuthenticationCredentialsRequest(
-                                                    new ClientController(
-                                                            config.clientFinder(),
-                                                            new RefreshTokenActivity(config.tokens(), idTokenFactory, config.identityFinder())
-                                                    ))
-
-                                    )
-                            ),
-                            // JWT Support
-                            new RequestHandlerMatchingParam("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer", new RequiresParam("assertion",
-                                    new InstantaneousRequestController(
-                                            new JwtController(
-                                                    signatureFactory,
-                                                    config.tokens(),
-                                                    config.jwtKeyStore(),
-                                                    config.identityFinder(),
-                                                    idTokenFactory
-                                            )))
-                            ))
-            ),
-            new FkRegex(".*/revoke",
-                    new RequiresParam("token",
-                            new InstantaneousRequestController(
-                                    new ClientAuthenticationCredentialsRequest(
-                                            new RevokeTokenController(config.clientFinder(), config.tokens())
-                                    )
-                            )
-                    )
-            ),
-            new FkRegex(".*/tokenInfo",
-                    new RequiresParam("access_token",
-                            new InstantaneousRequestController(
-                                    new TokenInfoController(config.tokens(), config.identityFinder(), idTokenFactory)
-                            )
-                    )
-            ),
-            new FkRegex(".*/userInfo",
-                    new RequiresParam("access_token",
-                            new InstantaneousRequestController(
-                                    new UserInfoController(config.identityFinder(), config.tokens())
-                            ))
-            ),
-            new FkRegex(".*/certs", new PublicCertsController(config.keyStore()))
-    );
-
-    servletApiSupport = new ServletApiSupport(fork);
+    apiSupport = new OAuth2ApiSupportFactory().create(config());
   }
 
   @Override
   protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
     super.service(req, resp);
+
   }
 
   @Override
@@ -140,7 +32,7 @@ public abstract class OAuth2Servlet extends HttpServlet {
 
   @Override
   protected void doPost(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
-    servletApiSupport.serve(req, resp);
+    apiSupport.serve(req, resp);
   }
 
   protected abstract OAuth2Config config();


### PR DESCRIPTION
The library had a strog dependency to the HttpServlet. All the endpoint
setups were configured in the OAuth2Servlet, so when we try to integrate
the oauth2 library in our code we should use this servlet. This makes
the integration a litle bit restrictive and cause troubles if would like
to use frameworks like SparkJava.
Now the configurations logic was moved out and separated from the need to
use directly the HttpServlet in your project

SparkJava integration example : 
```kotlin
fun main(args: Array<String>) {

    val tokens = null
    val jwtKeyStore = null
    val keyStore = null
    val identityFinder = null
    val resourceOwnerIdentityFinder = null
    val clientAuthorizationRepository = null
    val clientFinder = null
    val oauth2Config  = OAuth2Config.newConfig()
                .tokens(tokens)
                .jwtKeyStore(jwtKeyStore)
                .keyStore(keyStore)
                .identityFinder(identityFinder)
                .resourceOwnerIdentityFinder(resourceOwnerIdentityFinder)
                .clientAuthorizationRepository(clientAuthorizationRepository)
                .clientFinder(clientFinder)
                .loginPageUrl("/ServiceLogin?continue=")
                .build()
    val oauth2ServletApi = Oauth2ServlertApiSupportFactory().create(oauth2Config)

    Spark.path("/o/oauth2/v1/") {
        Spark.get("*", Oauth2Handler(oauth2ServletApi))
        Spark.post("*", Oauth2Handler(oauth2ServletApi))
    }

    println("App is up and running")
}

class Oauth2Handler(private val oauth2ServletApi: Oauth2ServlertApiSupport) : Route {

    override fun handle(request: Request?, response: Response?): Any? {

        oauth2ServletApi.serve(request!!.raw(), response!!.raw())

        return response.raw()
    }
}
```

